### PR TITLE
Feature/validate claude plugin

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -e
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+claude plugins validate .
+
+if [ -d plugins ]; then
+  for plugin_dir in plugins/*/; do
+    [ -d "$plugin_dir" ] || continue
+    claude plugins validate "$plugin_dir"
+  done
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,10 @@ for f in plugins/mercadopago/skills/*/SKILL.md; do head -1 "$f"; done
 
 ## pre-commit
 
-This repo has no `.pre-commit-config.yaml`. When committing, use:
+This repo uses a git hook in `.githooks/pre-commit` to run `claude plugins validate .` and then validate each first-level plugin directory under `plugins/*/` before each commit.
+
+Mandatory setup:
 
 ```bash
-PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit -m "message"
+bash scripts/install-git-hooks.sh
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ A Claude Code plugin that gives you an AI-powered integration assistant for the 
 /plugin install mercadopago@mercadopago-claude-marketplace
 ```
 
+If you are developing this repository locally, you must run `bash scripts/install-git-hooks.sh` before making commits. This is required to activate the pre-commit hook. The validation command expects `claude` to be available on the machine.
+
 ### 3. Connect your account
 
 Run the setup script from your **terminal** (not inside Claude Code):

--- a/docs/components.json
+++ b/docs/components.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-20T21:48:20.200156+00:00",
+  "generated_at": "2026-04-27T19:11:56.406811+00:00",
   "plugin": {
     "name": "mercadopago",
     "version": "3.0.0",

--- a/plugins/mercadopago/skills/mp-checkout-bricks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-checkout-bricks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mp-checkout-bricks
-description: Checkout Bricks integration for Mercado Pago. Single skill with internal modules for Payment Brick, Card Payment Brick, Wallet Brick, and Status Screen Brick. Use when: Bricks, Payment Brick, Card Payment Brick, Wallet Brick, Status Screen Brick, embedded payment form, formulário de pagamento embutido, componente de pago.
+description: 'Checkout Bricks integration for Mercado Pago. Single skill with internal modules for Payment Brick, Card Payment Brick, Wallet Brick, and Status Screen Brick. Use when: Bricks, Payment Brick, Card Payment Brick, Wallet Brick, Status Screen Brick, embedded payment form, formulário de pagamento embutido, componente de pago.'
 license: Apache-2.0
 metadata:
   version: "1.0.0"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+echo "Configured git hooks path: .githooks"


### PR DESCRIPTION
## Summary

Add a mandatory local git hook setup that validates the marketplace root and each first-level plugin directory before commits, and fix the `mp-checkout-bricks` skill frontmatter parsing error.

## Changes

- Add a versioned pre-commit hook in `.githooks/pre-commit` that runs `claude plugins validate .` and then validates each `plugins/*/` directory.
- Add `scripts/install-git-hooks.sh` to configure `core.hooksPath` for the repository.
- Update `CLAUDE.md` and `README.md` to make the hook setup mandatory for contributors.
- Fix the `mp-checkout-bricks` skill `description` frontmatter so YAML parses correctly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Testing

- [x] Manual testing performed

## Screenshots

<img width="1193" height="455" alt="Captura de Tela 2026-04-28 às 09 34 09" src="https://github.com/user-attachments/assets/5d69b6e8-b11d-4075-af51-7ca182a496e5" />


## Related Issues

None.
