### PR TITLE
fix: deprecate sandbox_init_point for Checkout Pro testing

### DIFF
--- a/plugins/mercadopago/agents/mp-integration-expert.md
+++ b/plugins/mercadopago/agents/mp-integration-expert.md
@@ -152,6 +152,7 @@ Mercado Pago deprecated the old sandbox credentials with `TEST-` prefix. The cur
 - **Never suggest using credentials with `TEST-` prefix** — they are legacy and no longer issued
 - **Never ask if a credential is "sandbox" or "test" based on its prefix** — both test and production credentials start with `APP_USR-`
 - **How to obtain test credentials**: In the Developer Dashboard, navigate to *Tus integraciones > Datos de integracion > Credenciales* (right panel) > click **"Prueba"**. Alternative path: *Tus integraciones > Detalles de aplicacion > Pruebas > Credenciales de prueba*. For Brazil (Portuguese): *Suas integrações > Dados de integração > Credenciais* > click **"Teste"**.
+- **Checkout Pro testing**: Always use `init_point` (NOT `sandbox_init_point`) to redirect test users to the checkout. The `sandbox_init_point` parameter is deprecated and will be discontinued soon. For the complete test purchase flow, consult `{DOMAIN}/developers/{LANG}/docs/checkout-pro/integration-test/test-purchase`.
 - **Environment setup guide**: Use `search_documentation` to find the environment setup guide for the specific product being integrated (e.g., search "configure environment {product}"). Do not hardcode a single product URL.
 
 ## SDK Installation Reference

--- a/plugins/mercadopago/agents/mp-integration-expert.md
+++ b/plugins/mercadopago/agents/mp-integration-expert.md
@@ -152,7 +152,7 @@ Mercado Pago deprecated the old sandbox credentials with `TEST-` prefix. The cur
 - **Never suggest using credentials with `TEST-` prefix** — they are legacy and no longer issued
 - **Never ask if a credential is "sandbox" or "test" based on its prefix** — both test and production credentials start with `APP_USR-`
 - **How to obtain test credentials**: In the Developer Dashboard, navigate to *Tus integraciones > Datos de integracion > Credenciales* (right panel) > click **"Prueba"**. Alternative path: *Tus integraciones > Detalles de aplicacion > Pruebas > Credenciales de prueba*. For Brazil (Portuguese): *Suas integrações > Dados de integração > Credenciais* > click **"Teste"**.
-- **Checkout Pro testing**: Always use `init_point` (NOT `sandbox_init_point`) to redirect test users to the checkout. The `sandbox_init_point` parameter is deprecated and will be discontinued soon. For the complete test purchase flow, consult `{DOMAIN}/developers/{LANG}/docs/checkout-pro/integration-test/test-purchase`.
+- **Checkout Pro testing**: Always use `init_point` (NOT `sandbox_init_point`) to redirect test users to the checkout. The `sandbox_init_point` parameter is deprecated and will be discontinued soon. For the complete test purchase flow, consult MCP (`search_documentation` with term "checkout pro test purchase").
 - **Environment setup guide**: Use `search_documentation` to find the environment setup guide for the specific product being integrated (e.g., search "configure environment {product}"). Do not hardcode a single product URL.
 
 ## SDK Installation Reference

--- a/plugins/mercadopago/skills/mp-checkout-online/SKILL.md
+++ b/plugins/mercadopago/skills/mp-checkout-online/SKILL.md
@@ -57,6 +57,8 @@ Developer needs to accept online payments
 
 **Gotcha**: `currency_id` must match the country. ARS for Argentina, BRL for Brazil, etc. See agent country detection.
 
+**Gotcha**: For testing, always use `init_point` to redirect the test user to the checkout. Do NOT use `sandbox_init_point` — it is deprecated and will be discontinued. See `{DOMAIN}/developers/{LANG}/docs/checkout-pro/integration-test/test-purchase`.
+
 ## Integration Flow: Checkout API
 
 ### Card payments
@@ -124,7 +126,7 @@ CBP: Requires specific country-pair approval.
 
 ## Testing
 
-- Use `init_point` for Checkout Pro
+- **Checkout Pro**: Use `init_point` to redirect test users to the checkout. Do NOT use `sandbox_init_point` — it is deprecated and will be discontinued. Follow the test guide at `{DOMAIN}/developers/{LANG}/docs/checkout-pro/integration-test/test-purchase`
 - Use production credentials (`APP_USR-*`) of a **test user** — Mercado Pago no longer uses `TEST-` sandbox credentials
 - For automated test credentials: access the Developer Dashboard > application details > test credentials (available directly without creating test users)
 - Create test users from the Developer Dashboard or via the MCP tool `create_test_user` if needed

--- a/plugins/mercadopago/skills/mp-checkout-online/SKILL.md
+++ b/plugins/mercadopago/skills/mp-checkout-online/SKILL.md
@@ -57,7 +57,7 @@ Developer needs to accept online payments
 
 **Gotcha**: `currency_id` must match the country. ARS for Argentina, BRL for Brazil, etc. See agent country detection.
 
-**Gotcha**: For testing, always use `init_point` to redirect the test user to the checkout. Do NOT use `sandbox_init_point` — it is deprecated and will be discontinued. See `{DOMAIN}/developers/{LANG}/docs/checkout-pro/integration-test/test-purchase`.
+**Gotcha**: For testing, always use `init_point` to redirect the test user to the checkout. Do NOT use `sandbox_init_point` — it is deprecated and will be discontinued. For the test purchase flow, consult MCP (`search_documentation` with term "checkout pro test purchase").
 
 ## Integration Flow: Checkout API
 
@@ -126,7 +126,7 @@ CBP: Requires specific country-pair approval.
 
 ## Testing
 
-- **Checkout Pro**: Use `init_point` to redirect test users to the checkout. Do NOT use `sandbox_init_point` — it is deprecated and will be discontinued. Follow the test guide at `{DOMAIN}/developers/{LANG}/docs/checkout-pro/integration-test/test-purchase`
+- **Checkout Pro**: Use `init_point` to redirect test users to the checkout. Do NOT use `sandbox_init_point` — it is deprecated and will be discontinued. For the test purchase flow, consult MCP (`search_documentation` with term "checkout pro test purchase")
 - Use production credentials (`APP_USR-*`) of a **test user** — Mercado Pago no longer uses `TEST-` sandbox credentials
 - For automated test credentials: access the Developer Dashboard > application details > test credentials (available directly without creating test users)
 - Create test users from the Developer Dashboard or via the MCP tool `create_test_user` if needed


### PR DESCRIPTION
## Summary

- Deprecate `sandbox_init_point` parameter in Checkout Pro testing flow
- Developers must use `init_point` (works for both production and test users) instead
- Added warnings in 3 locations: agent Testing Model, Checkout Pro integration gotchas, and checkout-online Testing section
- Links to official test purchase documentation

## Context

`sandbox_init_point` will be discontinued soon. The correct way to test Checkout Pro is using `init_point` with test user credentials (`APP_USR-*`). Reference: https://www.mercadopago.com.ar/developers/es/docs/checkout-pro/integration-test/test-purchase

## Files changed

- `plugins/mercadopago/agents/mp-integration-expert.md` — Testing Model section
- `plugins/mercadopago/skills/mp-checkout-online/SKILL.md` — Checkout Pro gotcha + Testing section

## Test plan

- [x] Agent stays under 200 lines (196)
- [x] `sandbox_init_point` warning appears in all 3 relevant locations
- [x] No `tools:` field in skill frontmatter