### PR TITLE
fix/content validation fixes from mp-review audit

### DIFF
--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -20,7 +20,7 @@ Then restart Claude Code. The MCP server will read the token from the keychain a
 
 > Your Access Token is never stored in any file. Claude Code cannot read the OS keychain — only the MCP server process accesses it.
 
-Get your Access Token at: https://www.mercadopago.com.ar/developers/panel/app
+Get your Access Token at: `https://{DOMAIN}/developers/panel/app` (replace `{DOMAIN}` with your country's domain — e.g. `www.mercadopago.com.ar` for Argentina)
 
 ## Products Covered
 
@@ -28,12 +28,12 @@ Get your Access Token at: https://www.mercadopago.com.ar/developers/panel/app
 |---------|-------|-------------|
 | Checkout Pro | `mp-checkout-online` | Redirect-based payment with preferences |
 | Checkout Bricks | `mp-checkout-bricks` | Payment Brick, Card Payment Brick, Wallet Brick, Status Screen Brick |
-| Payments API | `mp-checkout-online` | Direct server-to-server payment with card tokenization |
+| Checkout API / Checkout Transparente (Brazil) | `mp-checkout-online` | Direct server-to-server payment with card tokenization |
 | 3D Secure | `mp-checkout-online` | Additional cardholder authentication |
 | Cross-Border Payments | `mp-checkout-online` | Accept payments from other countries |
-| Webhooks | `mp-notifications` | HMAC-signed webhook handling, IPN |
-| QR Attended / Dynamic | `mp-instore` | In-store QR code payments |
-| Point | `mp-instore` | Physical card reader devices |
+| Webhooks | `mp-notifications` | HMAC-signed webhook handling, IPN (legacy) |
+| QR Attended / Dynamic | `mp-instore` | In-store QR code payments (AR, BR, CL, UY) |
+| Point | `mp-instore` | Physical card reader devices (AR, BR, CL, MX) |
 | Orders | `mp-orders` | Orders, OU + QR |
 | Subscriptions | `mp-subscriptions` | Recurring billing, plans, preapprovals |
 | Wallet Connect | `mp-wallet` | Link user wallets, debt payments, massive links |
@@ -98,7 +98,9 @@ See [PLUGIN_SETTINGS.md](./PLUGIN_SETTINGS.md) for per-project configuration opt
 
 ## Resources
 
-- [Mercado Pago Developer Docs](https://www.mercadopago.com.ar/developers/en/docs)
-- [API Reference](https://www.mercadopago.com.ar/developers/en/reference)
-- [SDKs](https://www.mercadopago.com.ar/developers/en/docs/sdks-library/landing)
-- [Credentials Dashboard](https://www.mercadopago.com.ar/developers/panel/app)
+Replace `{DOMAIN}` with your country's domain and `{LANG}` with `es`, `pt` (Brazil), or `en`.
+
+- [Mercado Pago Developer Docs](https://{DOMAIN}/developers/{LANG}/docs)
+- [API Reference](https://{DOMAIN}/developers/{LANG}/reference)
+- [SDKs](https://{DOMAIN}/developers/{LANG}/docs/sdks-library/landing)
+- [Credentials Dashboard](https://{DOMAIN}/developers/panel/app)

--- a/plugins/mercadopago/agents/mp-integration-expert.md
+++ b/plugins/mercadopago/agents/mp-integration-expert.md
@@ -59,7 +59,7 @@ After determining the country, identify which product the developer needs by mat
 
 | Signal in project or conversation | Skill to activate |
 |---|---|
-| `preference`, `init_point`, `back_urls`, Checkout Pro, Checkout API, `payment.create`, 3DS, CBP, on-site checkout | `mp-checkout-online` |
+| `preference`, `init_point`, `back_urls`, Checkout Pro, Checkout API, Checkout Transparente, transparente, `payment.create`, 3DS, CBP, on-site checkout | `mp-checkout-online` |
 | Bricks, Payment Brick (all-in-one: cards, Pix, Boleto, OXXO, PSE, Yape, installments), Card Payment Brick (card-only PCI, tokenization), Wallet Brick (one-click MP, saved cards, balance, Mercado Credito), Status Screen Brick (payment result, 3DS challenge), embedded payment form | `mp-checkout-bricks` |
 | `notification_url`, `x-signature`, webhook, IPN, HMAC, retry | `mp-notifications` |
 | QR, `qr_code`, Point, POS, kiosko, instore, presencial | `mp-instore` |
@@ -179,18 +179,20 @@ Replace `{DOMAIN}` with the country domain and `{LANG}` with the language code (
 | Resource | URL template |
 |----------|-------------|
 | API Reference | `https://{DOMAIN}/developers/{LANG}/reference` |
-| Checkout Pro | `https://{DOMAIN}/developers/{LANG}/docs/checkout-pro/landing` |
-| Checkout Bricks | `https://{DOMAIN}/developers/{LANG}/docs/checkout-bricks/landing` |
+| Checkout Pro | `https://{DOMAIN}/developers/{LANG}/docs/checkout-pro/overview` |
+| Checkout Bricks | `https://{DOMAIN}/developers/{LANG}/docs/checkout-bricks/overview` |
 | Webhooks | `https://{DOMAIN}/developers/{LANG}/docs/your-integrations/notifications/webhooks` |
 | SDKs | `https://{DOMAIN}/developers/{LANG}/docs/sdks-library/landing` |
 | Credentials | `https://{DOMAIN}/developers/{LANG}/docs/your-integrations/credentials` |
 | Dev Environment Setup | Use `search_documentation` to find the setup guide for the specific product |
-| QR Code | `https://{DOMAIN}/developers/{LANG}/docs/qr-code/landing` |
-| Subscriptions | `https://{DOMAIN}/developers/{LANG}/docs/subscriptions/landing` |
-| Marketplace | `https://{DOMAIN}/developers/{LANG}/docs/marketplace/landing` |
-| Checkout API | `https://{DOMAIN}/developers/{LANG}/docs/checkout-api/landing` |
-| Point | `https://{DOMAIN}/developers/{LANG}/docs/mp-point/landing` |
-| Orders | `https://{DOMAIN}/developers/{LANG}/docs/orders/landing` |
+| QR Code | `https://{DOMAIN}/developers/{LANG}/docs/qr-code/overview` |
+| Subscriptions | `https://{DOMAIN}/developers/{LANG}/docs/subscriptions/overview` |
+| Marketplace (via Checkout Pro) | `https://{DOMAIN}/developers/{LANG}/docs/checkout-pro/how-tos/integrate-marketplace` |
+| Marketplace (via Checkout API) | `https://{DOMAIN}/developers/{LANG}/docs/checkout-api-payments/how-tos/integrate-marketplace` |
+| Checkout API (Orders — AR, BR, MX) | `https://{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/overview` |
+| Checkout API (Payments — CL, UY, PE, CO) | `https://{DOMAIN}/developers/{LANG}/docs/checkout-api-payments/overview` |
+| Point | `https://{DOMAIN}/developers/{LANG}/docs/mp-point/overview` |
+| Orders | `https://{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/overview` |
 | Wallet Connect | `https://{DOMAIN}/developers/{LANG}/docs/wallet-connect/landing` |
 
 Always use the country-specific links when sharing documentation with the user.

--- a/plugins/mercadopago/commands/mp-connect.md
+++ b/plugins/mercadopago/commands/mp-connect.md
@@ -65,7 +65,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh --remove
 
 ### Getting an Access Token
 
-Direct the user to: https://www.mercadopago.com.ar/developers/panel/app
+Direct the user to: `https://{DOMAIN}/developers/panel/app` (use the domain for their country)
 
 Steps:
 1. Log in to the Mercado Pago Developer Dashboard

--- a/plugins/mercadopago/commands/mp-review.md
+++ b/plugins/mercadopago/commands/mp-review.md
@@ -22,7 +22,7 @@ If `$ARGUMENTS` is provided, narrow the review to that scope:
 - **checkout** — Preference creation, back_urls, payment flow
 - **bricks** — Bricks setup, SDK JS initialization and customization, callbacks handling, troubleshooting common errors
 - **qr** — QR code setup, store/POS configuration, order creation
-- **point** — Device registration, payment intents, firmware, Point webhook (`point_integration_wh`)
+- **point** — Device registration, Orders API order creation, firmware, Point webhook (`orders` topic)
 - **subscriptions** — Plan setup, preapproval flow, invoice handling
 - **marketplace** — OAuth flow, split payments, application_fee, seller management
 - **errors** — Error handling, API error responses, retry logic, edge cases
@@ -49,7 +49,7 @@ If no argument is given, perform a full review.
    - **Bricks**: SDK initialization, container div before `create()`, onSubmit sends formData to backend, server-side payment with token, amount consistency between Brick and server
    - **Payments API**: Token handling, payer data, installments, issuer_id
    - **QR**: Store/POS setup, order fields, QR lifecycle
-   - **Point**: Device registration, payment intent creation, firmware compliance, `point_integration_wh` notification handling
+   - **Point**: Device registration, Orders API order creation, firmware compliance, `orders` notification topic
    - **Subscriptions**: Plan configuration, preapproval flow, invoice handling
    - **Marketplace**: OAuth flow, split configuration, application_fee limits
    - **Webhooks**: 200 response before processing, idempotency, async processing

--- a/plugins/mercadopago/skills/mp-checkout-bricks/card-payment/index.md
+++ b/plugins/mercadopago/skills/mp-checkout-bricks/card-payment/index.md
@@ -109,7 +109,7 @@ After implementation is complete, generate and output a consolidated report:
 3. Go to production (swap TEST- keys for live keys)
 
 ### 🔗 Resources
-- [Card Payment Brick Docs](https://www.mercadopago.com.br/developers/pt/docs/checkout-bricks/card-payment-brick)
+- [Card Payment Brick Docs](https://{DOMAIN}/developers/{LANG}/docs/checkout-bricks/card-payment-brick/introduction)
 - [Troubleshooting](references/troubleshooting.md)
 - [Customization](references/customization.md)
 ```

--- a/plugins/mercadopago/skills/mp-checkout-bricks/payment/index.md
+++ b/plugins/mercadopago/skills/mp-checkout-bricks/payment/index.md
@@ -131,7 +131,7 @@ After implementation is complete, generate and output a consolidated report:
 4. Go to production (swap TEST- keys for live keys)
 
 ### 🔗 Resources
-- [Payment Brick Docs](https://www.mercadopago.com.br/developers/pt/docs/checkout-bricks/payment-brick)
+- [Payment Brick Docs](https://{DOMAIN}/developers/{LANG}/docs/checkout-bricks/payment-brick/introduction)
 - [Troubleshooting](references/troubleshooting.md)
 - [Customization](references/customization.md)
 ```

--- a/plugins/mercadopago/skills/mp-checkout-bricks/status-screen/index.md
+++ b/plugins/mercadopago/skills/mp-checkout-bricks/status-screen/index.md
@@ -101,7 +101,7 @@ After implementation is complete, generate and output a consolidated report:
 3. Go to production (swap TEST- keys for live keys)
 
 ### 🔗 Resources
-- [Status Screen Brick Docs](https://www.mercadopago.com.br/developers/pt/docs/checkout-bricks/status-screen-brick)
+- [Status Screen Brick Docs](https://{DOMAIN}/developers/{LANG}/docs/checkout-bricks/status-screen-brick/introduction)
 - [Troubleshooting](references/troubleshooting.md)
 - [Customization](references/customization.md)
 ```

--- a/plugins/mercadopago/skills/mp-checkout-bricks/wallet/index.md
+++ b/plugins/mercadopago/skills/mp-checkout-bricks/wallet/index.md
@@ -96,7 +96,7 @@ After implementation is complete, generate and output a consolidated report:
 3. Go to production (swap TEST- keys for live keys)
 
 ### 🔗 Resources
-- [Wallet Brick Docs](https://www.mercadopago.com.br/developers/pt/docs/checkout-bricks/wallet-brick)
+- [Wallet Brick Docs](https://{DOMAIN}/developers/{LANG}/docs/checkout-bricks/wallet-brick/introduction)
 - [Troubleshooting](references/troubleshooting.md)
 - [Customization](references/customization.md)
 ```

--- a/plugins/mercadopago/skills/mp-checkout-online/SKILL.md
+++ b/plugins/mercadopago/skills/mp-checkout-online/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mp-checkout-online
-description: Online checkout integration patterns for Mercado Pago. Covers Checkout Pro, Checkout API, 3D Secure, and Cross-Border Payments. Use when implementing any web-based payment flow.
+description: Online checkout integration patterns for Mercado Pago. Covers Checkout Pro, Checkout API, Checkout Transparente (Brazil), 3D Secure, and Cross-Border Payments. Use when implementing any web-based payment flow.
 license: Apache-2.0
 metadata:
   version: "3.0.0"
@@ -61,6 +61,8 @@ Developer needs to accept online payments
 
 ## Integration Flow: Checkout API
 
+**API by country:** Orders API (default) for AR, BR, CL, MX — Payments API (default; Orders API also available) for UY, PE, CO. Consult MCP for current country-specific guidance.
+
 ### Card payments
 1. Client: Tokenize card using MercadoPago.js `cardForm` or `createCardToken`
 2. Client: Send token + payment details to server
@@ -87,7 +89,7 @@ Developer needs to accept online payments
 - Adds an iframe challenge flow for the buyer
 - Only integrable for Checkout API or Checkout Bricks. Checkout Pro is already integrated by default
 - Always use `binary_mode: false`, otherwise the payment won't be able to show the challenge or `pending` status. 
-- **For endpoints, payloads, and implementation details**: Consult the MCP server or fetch docs at `{DOMAIN}/developers/{LANG}/docs/checkout-api/3ds`
+- **For endpoints, payloads, and implementation details**: Consult the MCP server or fetch docs at `{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/payment-management/integrate-3ds` (available for AR, BR, MX only)
 
 ## Cross-Border Payments (CBP) -- Skeleton
 
@@ -122,6 +124,8 @@ Developer needs to accept online payments
 
 All 7 countries: Argentina, Brazil, Mexico, Chile, Colombia, Peru, Uruguay.
 
+**Note:** For Brazil (MLB), the product is called **Checkout Transparente** — not Checkout API. Both are handled by this skill.
+
 CBP: Requires specific country-pair approval.
 
 ## Testing
@@ -148,8 +152,9 @@ When helping a developer, use the Mercado Pago MCP server (`mercadopago`) to get
 
 If MCP is unavailable:
 
-- `{DOMAIN}/developers/{LANG}/docs/checkout-pro/landing` -- Checkout Pro guide
-- `{DOMAIN}/developers/{LANG}/docs/checkout-bricks/landing` -- Bricks guide
-- `{DOMAIN}/developers/{LANG}/docs/checkout-api/landing` -- Checkout API guide (note: this path may redirect to Orders API docs in some countries)
-- `{DOMAIN}/developers/{LANG}/docs/checkout-api/3ds` -- 3DS guide
+- `{DOMAIN}/developers/{LANG}/docs/checkout-pro/overview` -- Checkout Pro guide
+- `{DOMAIN}/developers/{LANG}/docs/checkout-bricks/overview` -- Bricks guide
+- `{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/overview` -- Checkout API guide (AR, BR, MX)
+- `{DOMAIN}/developers/{LANG}/docs/checkout-api-payments/overview` -- Checkout API guide (CL, UY, PE, CO)
+- `{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/payment-management/integrate-3ds` -- 3DS guide (AR, BR, MX only)
 - `{DOMAIN}/developers/{LANG}/docs/your-integrations/test/cards` -- Test cards

--- a/plugins/mercadopago/skills/mp-instore/SKILL.md
+++ b/plugins/mercadopago/skills/mp-instore/SKILL.md
@@ -52,14 +52,14 @@ Need in-store payments
 ## Integration Flow: QR Static (Attended)
 
 1. Create a Store and a POS in Mercado Pago (one-time setup). The QR code is generated when the POS is created.
-2. Create an order associated to that POS via the Unified Orders API.
+2. Create an order associated to that POS via the Orders API.
 3. Buyer scans the QR code with the Mercado Pago app.
 4. Mercado Pago processes the payment.
 5. Receive webhook notification with payment result.
 
 ## Integration Flow: QR Dynamic
 
-1. Create an order via the Unified Orders API. The response includes the QR data to display.
+1. Create an order via the Orders API. The response includes the QR data to display.
 2. Display the generated QR to the buyer (on screen or printed). Note: the QR expires after a set time — refresh if needed.
 3. Buyer scans with the Mercado Pago app.
 4. Mercado Pago processes the payment.
@@ -68,7 +68,7 @@ Need in-store payments
 ## Integration Flow: QR Hybrid
 
 1. Create a Store and a POS in Mercado Pago (one-time setup). The static QR code is generated when the POS is created.
-2. Create an order via the Unified Orders API. The order is linked to the static QR of the POS and a unique dynamic QR is generated simultaneously.
+2. Create an order via the Orders API. The order is linked to the static QR of the POS and a unique dynamic QR is generated simultaneously.
 3. Display either the static or dynamic QR to the buyer.
 4. Buyer scans one of the QR codes with the Mercado Pago app.
 5. Mercado Pago processes the payment. The other QR is automatically invalidated.
@@ -79,7 +79,7 @@ Need in-store payments
 1. Create a Store and a POS in Mercado Pago (one-time setup).
 2. Register the physical device and associate it to the POS.
 3. Set the operating mode of the device via the Point API (`PDV` or `SELF_SERVICE`).
-4. Create an order via the Unified Orders API.
+4. Create an order via the Orders API.
 5. The device processes the card (chip, swipe, or contactless).
 6. Receive the result via webhook.
 
@@ -117,11 +117,16 @@ Need in-store payments
 
 Use the MCP server to retrieve current data for:
 - Store and POS creation endpoints and payloads
-- Unified Orders API schema and endpoints (for QR Static, QR Dynamic, QR Hybrid and Point)
+- Orders API schema and endpoints (for QR Static, QR Dynamic, QR Hybrid and Point)
 - Point device registration and operating mode configuration API
 - Order status codes and webhook payload examples
 
+## Testing
+
+- **QR**: Consult MCP (`search_documentation` with term "qr code test integration") or fetch `{DOMAIN}/developers/{LANG}/docs/qr-code/test-integration`
+- **Point**: Consult MCP (`search_documentation` with term "point integration test") or fetch `{DOMAIN}/developers/{LANG}/docs/mp-point/integration-test`
+
 ## What to Fetch from Docs
 
-- `{DOMAIN}/developers/{LANG}/docs/qr-code/landing`
-- `{DOMAIN}/developers/{LANG}/docs/mp-point/landing`
+- `{DOMAIN}/developers/{LANG}/docs/qr-code/overview`
+- `{DOMAIN}/developers/{LANG}/docs/mp-point/overview`

--- a/plugins/mercadopago/skills/mp-instore/references/instore-integration-guide.md
+++ b/plugins/mercadopago/skills/mp-instore/references/instore-integration-guide.md
@@ -49,7 +49,7 @@ Business Account
 ## Notification Flow
 
 - **QR**: Standard webhook events `payment.created` and `payment.updated`.
-- **Point**: Uses `point_integration_wh` event type.
+- **Point**: Uses `orders` topic (Orders API).
 - **Both**: Always verify the payment server-side after receiving the notification. Never trust client-side data alone.
 
 ## Common Integration Errors

--- a/plugins/mercadopago/skills/mp-money-out/SKILL.md
+++ b/plugins/mercadopago/skills/mp-money-out/SKILL.md
@@ -72,5 +72,5 @@ Use the MCP server to retrieve current data for:
 
 ## What to Fetch from Docs
 
-- `{DOMAIN}/developers/{LANG}/docs/money-out/landing` (if available)
-- `{DOMAIN}/developers/{LANG}/reference/disbursements`
+- `{DOMAIN}/developers/{LANG}/docs/payouts/overview` (if available)
+- `{DOMAIN}/developers/{LANG}/docs/payouts/resources/endpoints-map` (if available)

--- a/plugins/mercadopago/skills/mp-notifications/SKILL.md
+++ b/plugins/mercadopago/skills/mp-notifications/SKILL.md
@@ -24,7 +24,7 @@ Do NOT use for: payment creation (-> mp-checkout-online), QR notifications (-> m
 |---------|-------------|
 | Checkout Pro / Bricks / API | payment.created, payment.updated |
 | Subscriptions | plan.created, plan.updated, subscription.created, subscription.updated, invoice.created, invoice.updated |
-| Point / In-Store | point_integration_wh |
+| Point / In-Store | orders |
 | Marketplace | payment.created, payment.updated (with marketplace context) |
 | Orders API | order.created, order.updated |
 | Chargebacks | chargeback.created, chargeback.updated |

--- a/plugins/mercadopago/skills/mp-notifications/references/webhook-patterns.md
+++ b/plugins/mercadopago/skills/mp-notifications/references/webhook-patterns.md
@@ -11,7 +11,7 @@
 | subscription.updated | Subscription updated |
 | invoice.created | Subscription invoice created |
 | invoice.updated | Subscription invoice updated |
-| point_integration_wh | Point device event |
+| point_integration_wh | Point device event (legacy — old Point Integration API) |
 | chargeback.created | Chargeback initiated |
 | chargeback.updated | Chargeback status changed |
 | order.created | Order created (Orders API) |

--- a/plugins/mercadopago/skills/mp-orders/SKILL.md
+++ b/plugins/mercadopago/skills/mp-orders/SKILL.md
@@ -15,9 +15,20 @@ Mercado Pago Orders (Orden Unificada). Covers order flows, multi-payment orders,
 
 ## Products Covered
 
-- **Orders API**: The new unified order system (`POST /v1/orders`). Supports multiple payment methods, partial payments, and QR integration. Recommended for all new integrations.
+- **Orders API**: The unified orders system (`POST /v1/orders`). Supports multiple payment methods, partial payments, and QR integration. Recommended for all new integrations.
 - **Orders + QR**: Order combined with QR payment flow, enabling in-store payments within the Orders API framework.
 - **merchant_orders (Legacy)**: The older order entity from the legacy API. If you find `merchant_orders` in existing code, consider migrating to the Orders API.
+
+## Products That Use Orders API
+
+Orders API is the backend for multiple MP products — not a standalone product:
+
+| Product | Countries |
+|---------|-----------|
+| Checkout API / Checkout Transparente | AR, BR, CL, MX (default); UY, PE, CO (available) |
+| Checkout Bricks (automatic mode) | All countries |
+| Point | AR, BR, CL, MX |
+| QR Code | AR, BR, CL, UY |
 
 ## When to Use This Skill
 
@@ -61,7 +72,12 @@ Need flexible order management
 
 ## Country Availability
 
-- AR, BR, MX (check Mercado Pago documentation for expansion to additional countries).
+Orders API is available across all 7 countries, with scope varying by product:
+
+- **Checkout API / Checkout Transparente**: default in AR, BR, CL, MX — also available (non-default) in UY, PE, CO.
+- **Point**: AR, BR, CL, MX only.
+- **QR Code**: AR, BR, CL, UY only.
+- **Checkout Bricks**: all countries (automatic mode).
 
 ## What to Fetch from MCP
 
@@ -73,4 +89,4 @@ Use the MCP server to retrieve current data for:
 
 ## What to Fetch from Docs
 
-- `{DOMAIN}/developers/{LANG}/docs/orders/landing`
+- `{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/overview`

--- a/plugins/mercadopago/skills/mp-reporting/SKILL.md
+++ b/plugins/mercadopago/skills/mp-reporting/SKILL.md
@@ -68,4 +68,4 @@ All countries (report types may vary)
 - Generation endpoints
 - Download endpoints
 - Field descriptions
-- `{DOMAIN}/developers/{LANG}/docs/reports/landing`
+- `{DOMAIN}/developers/{LANG}/docs/reports/introduction`

--- a/plugins/mercadopago/skills/mp-sdks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-sdks/SKILL.md
@@ -124,4 +124,5 @@ What platform is the integration running on?
 ## What to Fetch from Docs
 
 - `{DOMAIN}/developers/{LANG}/docs/sdks-library/landing` — SDK overview and downloads
-- `{DOMAIN}/developers/{LANG}/docs/sdks-library/client-side` — MercadoPago.js and React SDK details
+- `{DOMAIN}/developers/{LANG}/docs/sdks-library/client-side/mp-js-v2` — MercadoPago.js details
+- `{DOMAIN}/developers/{LANG}/docs/sdks-library/client-side/sdk-js-react-installation` — React SDK details

--- a/plugins/mercadopago/skills/mp-security/SKILL.md
+++ b/plugins/mercadopago/skills/mp-security/SKILL.md
@@ -80,4 +80,5 @@ Security feature needed
 - Supertoken API
 - 3DS configuration
 - Vault API
-- `{DOMAIN}/developers/{LANG}/docs/checkout-api/tokenization`
+- `{DOMAIN}/developers/{LANG}/docs/checkout-api-orders/saved-cards` -- saved cards / tokenization (AR, BR, MX)
+- `{DOMAIN}/developers/{LANG}/docs/checkout-api-payments/how-tos/payment-approval/saved-cards` -- saved cards / tokenization (CL, UY, PE, CO)

--- a/plugins/mercadopago/skills/mp-specialized/SKILL.md
+++ b/plugins/mercadopago/skills/mp-specialized/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 - **Yape (Peru)**: Mobile wallet integration
 - **Fintoc (Chile)**: Bank transfer via Fintoc
 - **PSE (Colombia)**: Bank transfer via PSE
-- **Other regional methods**: Pix (Brazil) is natively supported in Checkout API/Bricks. For the full list of available payment methods per country, consult MCP (`search_documentation`).
+- **Other regional methods**: Pix (Brazil) is natively supported in Checkout Transparente/Bricks. For the full list of available payment methods per country, consult MCP (`search_documentation`).
 
 ## When to Use
 

--- a/plugins/mercadopago/skills/mp-subscriptions/SKILL.md
+++ b/plugins/mercadopago/skills/mp-subscriptions/SKILL.md
@@ -81,4 +81,4 @@ Use the MCP server to retrieve current data for:
 
 ## What to Fetch from Docs
 
-- `{DOMAIN}/developers/{LANG}/docs/subscriptions/landing`
+- `{DOMAIN}/developers/{LANG}/docs/subscriptions/overview`


### PR DESCRIPTION
Applies all corrections identified by the devcontent-validators/mp-review skill:

**Product & API correctness (Critical)**
- Replace "Payments API" standalone product entry with "Checkout API / Checkout Transparente (Brazil)" in README
- Remove "payment intent" terminology for Point; replace with "Orders API order creation"
- Fix Point notification topic: point_integration_wh → orders (Orders API)
- Replace "Unified Orders API" (5x) with canonical "Orders API" in mp-instore
- Add Checkout Transparente (Brazil) distinction to mp-checkout-online
- Fix "Checkout API" → "Checkout Transparente" for Brazil/Pix in mp-specialized

**Content completeness (High)**
- Add cross-product mapping table to mp-orders (Checkout API, Point, QR all use Orders API)
- Fix mp-orders country availability: all 7 countries with per-product scope
- Add "Checkout Transparente / transparente" routing signals to agent
- Add per-country API note to mp-checkout-online Checkout API flow

**Terminology & legacy labels (Medium)**
- Mark IPN as legacy in README
- Add Testing section to mp-instore with validated URLs

**URL fixes — devsite canonical paths**
- All /landing redirects → /overview (checkout-bricks, checkout-pro, subscriptions, mp-point, qr-code)
- marketplace/landing (404) → split into checkout-pro and checkout-api-payments how-tos
- orders/landing (404) → checkout-api-orders/overview
- reports/landing (404) → reports/introduction
- checkout-api/landing|3ds|tokenization → versioned paths (checkout-api-orders / checkout-api-payments)
- Bricks hardcoded .com.br URLs → {DOMAIN}/{LANG} dynamic templates + /introduction suffix
- sdks-library/client-side (404) → /client-side/mp-js-v2 + /sdk-js-react-installation
- reference/disbursements (404) → payouts/overview + payouts/resources/endpoints-map (if available)
- All hardcoded www.mercadopago.com.ar devsite URLs → {DOMAIN}/{LANG} dynamic templates
- Point/QR availability added to README product table