### PR TITLE
feat(v4.1): rescue missing Bricks gotchas + add Implementation Report

### DIFF
--- a/plugins/mercadopago/skills/mp-integrate/SKILL.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL.md
@@ -4,7 +4,7 @@ description: Wizard that scaffolds a complete Mercado Pago integration for any p
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.0.0"
+  version: "4.1.0"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, integration, wizard, checkout, bricks, qr, point, subscriptions, marketplace, orders, sdk"
@@ -468,6 +468,12 @@ Render only the section that matches the chosen product. These are the experient
 - For Card Payment Brick: amount validation happens server-side; never trust the amount echoed by the brick.
 - Wallet Brick requires the buyer to be logged into Mercado Pago — test users count as logged in if you use their credentials.
 - Status Screen Brick handles 3DS challenge rendering; do not also render your own 3DS iframe.
+- **Ad-blockers (uBlock, AdBlock Plus, Brave shields) block `sdk.mercadopago.com`** → the brick raises `FIELDS_SETUP_FAILED` and silently fails to mount. If a developer reports "the brick doesn't appear", check the ad-blocker before debugging code.
+- **Debit cards do NOT show an installments selector** — this is correct behavior, not a bug. Make sure the server accepts `installments: 1` for debit and does not require the selector field to be present.
+- **Never hardcode `preferenceId` as a placeholder** (e.g., `<PREFERENCE_ID>`, `YOUR_PREFERENCE_ID`, `"preference_id"`): the brick fails silently. The `preferenceId` must always be created dynamically on the server per buyer session.
+- **Status Screen Brick needs a `payment_id`, not an `order_id`** — extract it from the order response: when the order is paid, the `transactions.payments[]` array contains the payment object with the `id` you must pass to the brick.
+- **React: call `brickController.unmount()` in the `useEffect` cleanup** before re-mounting. Re-rendering without unmounting leaves zombie listeners that break form submission silently.
+- **`back_urls` must be on the same origin as the page that mounts the brick.** Cross-domain back_urls fail silently — the redirect after payment lands on a blank page with no error.
 
 ### qr
 - Static QR (printed sticker) requires **Store + POS** to be created via API before generating the QR — they are not auto-created.

--- a/plugins/mercadopago/skills/mp-review/SKILL.md
+++ b/plugins/mercadopago/skills/mp-review/SKILL.md
@@ -4,7 +4,7 @@ description: Review a Mercado Pago integration against the official quality chec
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.0.0"
+  version: "4.1.0"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, review, quality, checklist, security"
@@ -89,6 +89,14 @@ These items are not always part of `quality_checklist` but are mandatory for any
 
 ---
 
+## Step 5 — Render the Implementation Report (MANDATORY final step)
+
+After Steps 1–4 are complete, **always** render an Implementation Report as the last block of the output. This is the deliverable the developer keeps — it summarizes what's done, what's pending, and what to do next. Do not skip it, do not summarize it in prose; render the structured block below verbatim.
+
+The report is the source of truth for the developer's next session: it tells them exactly what was verified, what was flagged, and the next concrete action. Without it, the review feels open-ended and the developer doesn't know if they can ship.
+
+---
+
 ## Output format
 
 ```markdown
@@ -130,6 +138,33 @@ These items are not always part of `quality_checklist` but are mandatory for any
 **Summary**: X/Y required fields implemented, Z/W best practices adopted, S/9 security checks pass.
 
 > Want a deeper score? Provide a recent test payment ID (or order ID) and I'll run `quality_evaluation`.
+
+---
+
+## 📋 Implementation Report
+
+### ✅ Verified
+- [x] {item that passed — e.g., "Webhook handler validates x-signature with HMAC-SHA256"}
+- [x] {next passing item}
+
+### ⚠️ Needs attention
+- [ ] {actionable item with file:line — e.g., "Add idempotency key to POST /v1/payments at api/payments.js:42"}
+- [ ] {next pending item}
+
+### 🚫 Blockers (must fix before production)
+- [ ] {critical item — e.g., "Hardcoded APP_USR- token in config/mp.js:8 — move to env"}
+
+### 🎯 Next steps
+1. {The single most impactful action the developer should take next}
+2. {Follow-up actions in priority order}
+3. Re-run `/mp-review` after fixes to confirm the report.
+
+### 🔗 Resources used
+- MCP: `quality_checklist` ({date/time of call})
+- MCP: `quality_evaluation` (if it was run, with the payment_id/order_id used)
+- Skill: `mp-review` v4.1.0
+
+**Scores**: {X}/{Y} required, {Z}/{W} best practices, {S}/9 security. **Verdict**: {Ready for production | Needs fixes | Blocked}.
 ```
 
 ---

--- a/plugins/mercadopago/skills/mp-review/SKILL.md
+++ b/plugins/mercadopago/skills/mp-review/SKILL.md
@@ -141,25 +141,25 @@ The report is the source of truth for the developer's next session: it tells the
 
 ---
 
-## 📋 Implementation Report
+## Implementation Report
 
-### ✅ Verified
+### Verified
 - [x] {item that passed — e.g., "Webhook handler validates x-signature with HMAC-SHA256"}
 - [x] {next passing item}
 
-### ⚠️ Needs attention
+### Needs attention
 - [ ] {actionable item with file:line — e.g., "Add idempotency key to POST /v1/payments at api/payments.js:42"}
 - [ ] {next pending item}
 
-### 🚫 Blockers (must fix before production)
+### Blockers (must fix before production)
 - [ ] {critical item — e.g., "Hardcoded APP_USR- token in config/mp.js:8 — move to env"}
 
-### 🎯 Next steps
+### Next steps
 1. {The single most impactful action the developer should take next}
 2. {Follow-up actions in priority order}
 3. Re-run `/mp-review` after fixes to confirm the report.
 
-### 🔗 Resources used
+### Resources used
 - MCP: `quality_checklist` ({date/time of call})
 - MCP: `quality_evaluation` (if it was run, with the payment_id/order_id used)
 - Skill: `mp-review` v4.1.0

--- a/plugins/mercadopago/skills/mp-review/SKILL.md
+++ b/plugins/mercadopago/skills/mp-review/SKILL.md
@@ -40,6 +40,8 @@ Use `Grep`/`Glob` to find:
 Determine:
 
 - **API in use**: Payments API (`/v1/payments`) vs Orders API (`/v1/orders`). Both can coexist.
+  - **If the integration uses the Payments API**, it is on the legacy path. The Payments API is being deprecated; Mercado Pago is pushing all integrations toward the Orders API. Always include a `Needs attention` item in the Implementation Report recommending the migration, with the file:line where `/v1/payments` is called. Do **not** treat it as a Blocker (existing code still works), but flag it as forward-looking technical debt.
+  - **Exception**: Checkout Pro stays on preferences (the Orders API does not exist for Checkout Pro). Do not flag `/v1/checkout/preferences` as legacy.
 - **Products in use**: Checkout Pro/API, Bricks, Subscriptions, Marketplace, etc. — derive from endpoint patterns and request payloads.
 
 ---
@@ -148,8 +150,9 @@ The report is the source of truth for the developer's next session: it tells the
 - [x] {next passing item}
 
 ### Needs attention
-- [ ] {actionable item with file:line — e.g., "Add idempotency key to POST /v1/payments at api/payments.js:42"}
+- [ ] {actionable item with file:line — e.g., "Add idempotency key to POST /v1/orders at api/orders.js:42"}
 - [ ] {next pending item}
+- [ ] {if legacy `/v1/payments` is detected — e.g., "Migrate POST /v1/payments to the Orders API (POST /v1/orders) at api/payments.js:42. The Payments API is being deprecated."}
 
 ### Blockers (must fix before production)
 - [ ] {critical item — e.g., "Hardcoded APP_USR- token in config/mp.js:8 — move to env"}


### PR DESCRIPTION
## Context

An audit of `feature/v2` (v4.0.0) against the original `mp-checkout-bricks` skill on `main` (28 files, ~3,766 lines) found that the refactor lost ~40% of the experiential Bricks value when condensing sub-skills into the Gotchas Bank.

The refactor correctly removed ~48% of content that was DevSite-duplication. But it was a bit too aggressive: gotchas, anti-patterns and workflow closure that **the DevSite does not surface** got dropped along with the docs duplication.

This PR rescues those items **without breaking the 4-skill architecture**. No new skills, no new commands — just two surgical extensions.

## Changes

### 1. `mp-integrate` — Gotchas Bank, `bricks` section

Added 6 gotchas that were in the original `mp-checkout-bricks` `troubleshooting.md` files but did not make it into v4:

- **Ad-blockers block `sdk.mercadopago.com`** → `FIELDS_SETUP_FAILED`. Check before debugging code.
- **Debit cards do NOT show installments selector** — correct behavior, not a bug. Server must accept `installments: 1`.
- **Never hardcode `preferenceId` as placeholder** (`<PREFERENCE_ID>`, `YOUR_PREFERENCE_ID`): silent failure.
- **Status Screen Brick needs `payment_id`, not `order_id`** — extract from `transactions.payments[]` of the order.
- **React: `unmount()` in `useEffect` cleanup** before re-mount, or zombie listeners break the form.
- **`back_urls` must be same-origin** — cross-domain redirect lands on a blank page silently.

### 2. `mp-review` — Implementation Report (mandatory final step)

The original Bricks sub-skills required generating a closure report at the end of each integration. v4 removed it entirely. This PR puts it back, but at the **review** level (not the integration level), where it lives more naturally:

- **New Step 5**: Render Implementation Report (mandatory).
- **Output format extended** with a structured block: Verified / Needs attention / Blockers / Next steps / Resources used / Scores + Verdict.

The report is what the developer keeps. Without it the review feels open-ended.

### 3. Version bump

Both skills: `4.0.0` → `4.1.0`.

## Why this stays as 1 skill (no new skill added)

Three reasons:

1. **Respects intent-centric model.** v4 explicitly moved away from "1 skill per product". Adding `mp-bricks-gotchas` or `mp-troubleshooting` regresses to that pattern.
2. **The agent already routes correctly.** Adding a 5th skill adds a routing decision point with low ROI.
3. **Gotchas are contextual.** "Debit cards have no installments" is meaningless without the Card Payment Brick flow. They live next to the wizard that builds them.

## Verification

```bash
# Skills still 4
find plugins/mercadopago/skills -name "SKILL.md" | wc -l  # → 4

# No tools: field in any skill
grep -l "^tools:" plugins/mercadopago/skills/*/SKILL.md  # → empty

# Versions bumped
grep -r "version.*4.1.0" plugins/mercadopago/skills/  # → 2 matches
```

## Test plan

- [ ] Trigger `/mp-integrate product=bricks brick=payment` and confirm the new gotchas surface for the developer
- [ ] Trigger `/mp-review` on an existing integration and confirm the Implementation Report block appears at the end
- [ ] Confirm no regression on other product gotchas (checkout-pro, qr, point, subscriptions, marketplace)