### PR TITLE
ci: make validate.yml architecture-agnostic (unblock PR #30)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -61,7 +61,8 @@ jobs:
 
       - name: Verify required files exist
         run: |
-          files=(
+          # Fixed infrastructure files — must always exist regardless of skill architecture
+          required_files=(
             ".claude-plugin/marketplace.json"
             "plugins/mercadopago/.claude-plugin/plugin.json"
             "plugins/mercadopago/.mcp.json"
@@ -70,19 +71,36 @@ jobs:
             ".claude/settings.json"
             "plugins/mercadopago/agents/mp-integration-expert.md"
             "plugins/mercadopago/commands/mp-review.md"
-            "plugins/mercadopago/commands/mp-setup.md"
-            "plugins/mercadopago/skills/mp-checkout-online/SKILL.md"
-            "plugins/mercadopago/skills/mp-notifications/SKILL.md"
-            "plugins/mercadopago/skills/mp-checkout-bricks/SKILL.md"
             "plugins/mercadopago/PLUGIN_SETTINGS.md"
             "plugins/mercadopago/README.md"
             "README.md"
             "CONTRIBUTING.md"
           )
-          for f in "${files[@]}"; do
+          for f in "${required_files[@]}"; do
             if [ ! -f "$f" ]; then
               echo "MISSING: $f"
               exit 1
             fi
             echo "OK: $f"
           done
+
+          # Structural checks — architecture-agnostic, work for v3 (multi-product skills)
+          # and v4 (consolidated orchestration skills) alike.
+
+          # 1) At least one user-facing command beyond /mp-review must exist
+          #    (v3: /mp-setup; v4: /mp-integrate). /mp-connect is optional.
+          shopt -s nullglob
+          extra_commands=(plugins/mercadopago/commands/mp-{setup,integrate}.md)
+          if [ ${#extra_commands[@]} -eq 0 ]; then
+            echo "MISSING: at least one of mp-setup.md or mp-integrate.md must exist under plugins/mercadopago/commands/"
+            exit 1
+          fi
+          for f in "${extra_commands[@]}"; do echo "OK: $f"; done
+
+          # 2) At least one SKILL.md must exist under plugins/mercadopago/skills/
+          skill_count=$(find plugins/mercadopago/skills -name SKILL.md -type f | wc -l)
+          if [ "$skill_count" -lt 1 ]; then
+            echo "MISSING: no SKILL.md found under plugins/mercadopago/skills/"
+            exit 1
+          fi
+          echo "OK: found $skill_count SKILL.md file(s)"


### PR DESCRIPTION
## Context

PR #30 (`feature/v2` → `main`) is failing CI with:

```
MISSING: plugins/mercadopago/commands/mp-setup.md
```

The cause: `.github/workflows/validate.yml` hardcodes the v3 skill/command filenames (`mp-setup.md`, `mp-checkout-online`, `mp-checkout-bricks`, `mp-notifications`). The v4 refactor on `feature/v2` renames `mp-setup` → `mp-integrate` and consolidates 13 skills into 4. The new architecture is valid but the workflow does not know about it.

## Fix

Make the workflow validate **structure**, not exact file names.

| Check | Before | After |
|-------|--------|-------|
| Fixed infra files (manifest, hooks, agent, etc.) | Hardcoded list of 16 paths | Hardcoded list of 12 paths (only true infrastructure) |
| User-facing setup command | `mp-setup.md` (exact) | At least one of `mp-setup.md` or `mp-integrate.md` |
| Skills | 3 specific skills (`mp-checkout-online`, `mp-notifications`, `mp-checkout-bricks`) | At least one `SKILL.md` anywhere under `skills/` |

Result: both v3 (current main: 13 skills, `mp-setup.md`) **and** v4 (`feature/v2`: 4 skills, `mp-integrate.md`) pass validation. Future refactors that keep the basic plugin structure won't break CI either.

## Why this is safe

- All true infrastructure files (`plugin.json`, `marketplace.json`, `.mcp.json`, hooks, agent, `mp-review.md`, READMEs) remain hardcoded — these never change name.
- The relaxed checks still fail loudly if someone deletes all skills or both commands.
- No production code paths changed — only CI validation logic.

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] On main (v3): `find plugins/mercadopago/skills -name SKILL.md | wc -l` → 13 ✓, `mp-setup.md` exists ✓
- [x] On feature/v2 (v4): 4 SKILL.md ✓, `mp-integrate.md` exists ✓
- [ ] After merge, re-run CI on PR #30 — should pass
