### PR TITLE
feature/review-content-v2

### DIFF
--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -90,7 +90,9 @@ See [PLUGIN_SETTINGS.md](./PLUGIN_SETTINGS.md) for per-project configuration opt
 
 ## Resources
 
-- [Mercado Pago Developer Docs](https://www.mercadopago.com.ar/developers/en/docs)
-- [API Reference](https://www.mercadopago.com.ar/developers/en/reference)
-- [SDKs](https://www.mercadopago.com.ar/developers/en/docs/sdks-library/landing)
-- [Credentials Dashboard](https://www.mercadopago.com.ar/developers/panel/app)
+Replace `{DOMAIN}` with your country's domain (e.g. `www.mercadopago.com.ar` for Argentina, `www.mercadopago.com.br` for Brazil) and `{LANG}` with `es`, `pt` (Brazil), or `en`. See the full country list in `mp-integrate`.
+
+- [Mercado Pago Developer Docs](https://{DOMAIN}/developers/{LANG}/docs)
+- [API Reference](https://{DOMAIN}/developers/{LANG}/reference)
+- [SDKs](https://{DOMAIN}/developers/{LANG}/docs/sdks-library/landing)
+- [Credentials Dashboard](https://{DOMAIN}/developers/panel/app)

--- a/plugins/mercadopago/skills/mp-integrate/SKILL.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL.md
@@ -321,7 +321,7 @@ Build 1–3 targeted queries and call `mcp__plugin_mercadopago_mcp__search_docum
 
 Do **not** issue more than 3 queries. If a query returns generic results, refine once and stop.
 
-If MCP returns nothing useful for the requested combination (e.g., a product not yet documented for that country), say so explicitly and offer to fall back to **one** targeted `WebFetch` against `https://{DOMAIN}/developers/{LANG}/docs/{product-slug}/landing` (max 1 fetch). **Never queue multiple WebFetch calls for the same product in different languages or for the API reference plus the guide — that pattern is a bug.** If you catch yourself doing it, cancel and re-issue a more specific `search_documentation` query instead.
+If MCP returns nothing useful for the requested combination (e.g., a product not yet documented for that country), say so explicitly and offer to fall back to **one** targeted `WebFetch` (max 1 fetch). Try `https://{DOMAIN}/developers/{LANG}/docs/{product-slug}/overview` first; if that returns 404, retry with `https://{DOMAIN}/developers/{LANG}/docs/{product-slug}/landing`. **Never queue multiple WebFetch calls for the same product in different languages or for the API reference plus the guide — that pattern is a bug.** If you catch yourself doing it, cancel and re-issue a more specific `search_documentation` query instead.
 
 ---
 
@@ -376,7 +376,7 @@ Also ensure `.env` is in `.gitignore` (and `.env.example` is **not** ignored).
 - Test cards for the country: query MCP `search_documentation` with `"test cards {country}"`.
 
 ## 7. Docs (country-specific)
-- Product guide: https://{DOMAIN}/developers/{LANG}/docs/{product-slug}/landing
+- Product guide: https://{DOMAIN}/developers/{LANG}/docs/{product-slug}/overview (fallback: /landing)
 - API reference: https://{DOMAIN}/developers/{LANG}/reference
 
 ## 8. Gotchas
@@ -456,6 +456,7 @@ Render only the section that matches the chosen product. These are the experient
 - `external_reference` is your reconciliation anchor — set it on every preference/order.
 
 ### checkout-api
+- **Brazil (MLB)**: this product is called **Checkout Transparente** — use that name in MCP queries (e.g., `"checkout transparente orders node brazil"`). The integration flow is identical; only the product name differs.
 - Card tokens are single-use and expire in 7 days.
 - `binary_mode: false` is required for 3DS — otherwise no challenge is issued and the payment cannot reach `pending`.
 - `issuer_id` is required for some card BINs in some countries.
@@ -478,12 +479,12 @@ Render only the section that matches the chosen product. These are the experient
 ### qr
 - Static QR (printed sticker) requires **Store + POS** to be created via API before generating the QR — they are not auto-created.
 - Dynamic QR has a short TTL — generate one per buyer interaction, not one shared QR.
-- Attended QR (cashier app) flows through `merchant_orders`, not direct payments — wire the webhook to `merchant_order` topic.
+- Attended QR (cashier app) with Orders API uses the `orders` topic. Legacy attended QR flows through `merchant_orders` — wire the webhook to `merchant_order` topic only if using the legacy API.
 
 ### point
 - The device must be paired to a User ID (not the application). A device paired to the wrong user will silently reject `payment_intent`s.
 - After a firmware update the device may take ~2 minutes to come back online; do not retry `payment_intent` creation aggressively.
-- Webhook topic for Point is `point_integration_wh` — different from regular `payment` notifications.
+- Webhook topic for Point (Orders API) is `orders`. The legacy `point_integration_wh` topic belongs to the old Point Integration API — do not use it for new integrations.
 
 ### subscriptions
 - A `preapproval` without a `preapproval_plan_id` is allowed but cannot be migrated to a plan later — pick one model upfront.
@@ -504,6 +505,7 @@ Render only the section that matches the chosen product. These are the experient
 - Bank account validation is asynchronous; the disbursement may sit in `pending` until validation completes.
 
 ### smartapps
+- **Requires direct contact with the Mercado Pago team** — SmartApps is not self-service. Do not scaffold without confirming the developer has an active agreement with MP.
 - Smart Apps run on Point devices — code limits and APIs differ from server SDKs. Always query MCP for the SmartApp-specific guide.
 
 ---

--- a/plugins/mercadopago/skills/mp-webhooks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-webhooks/SKILL.md
@@ -103,9 +103,10 @@ The notification body contains `type` (the topic) and `data.id`. Common topics:
 | Topic | When | Resource to fetch |
 |-------|------|-------------------|
 | `payment` | Payment status change (Payments API) | `GET /v1/payments/{id}` |
-| `merchant_order` | Merchant order updated (Checkout Pro / QR attended) | `GET /merchant_orders/{id}` |
+| `orders` | Point / QR Code event (Orders API) | `GET /v1/orders/{id}` |
+| `merchant_order` | Merchant order updated — legacy (Checkout Pro / QR attended via legacy API) | `GET /merchant_orders/{id}` |
 | `topic_claims_integration_wh` | Chargebacks | `GET /v1/chargebacks/{id}` |
-| `point_integration_wh` | Point device events | Point API — query MCP for the country |
+| `point_integration_wh` | Point device events — legacy (old Point Integration API) | Point legacy API — query MCP for the country |
 | `subscription_preapproval` | Subscription status change | `GET /preapproval/{id}` |
 | `subscription_authorized_payment` | Recurring charge attempt | `GET /authorized_payments/{id}` |
 


### PR DESCRIPTION
## Content Validation Report

**Skill used:** `devcontent-validators/mp-review`
**Branch reviewed:** `feature/v2`
**Rules applied:** Rules 0–7
**Date:** 2026-05-11

---

### Issues Fixed

#### 🔴 Critical

**1. `point_integration_wh` expuesto como tópico vigente para Point** (`mp-webhooks/SKILL.md`)
- Con Orders API, Point usa el tópico `orders`. `point_integration_wh` es el tópico legacy de la vieja Point Integration API.
- Fix: agregado `orders | Point / QR Code event (Orders API)` y `point_integration_wh` marcado como legacy.

**2. `merchant_order` listado sin etiqueta legacy** (`mp-webhooks/SKILL.md`)
- `merchant_order` es el tópico del sistema legacy de merchant orders. Con Orders API, QR y Point usan `orders`.
- Fix: `merchant_order` marcado como `legacy (Checkout Pro / QR attended via legacy API)`.

**3. `checkout-api` sin distinción de naming para Brazil** (`mp-integrate/SKILL.md`)
- Para Brazil (MLB) el producto se llama Checkout Transparente, no Checkout API.
- Fix: nota agregada en gotchas de `checkout-api` indicando el nombre correcto para MLB y ajustando queries al MCP.

**4. Fallback WebFetch URL usa `{product-slug}/landing` — patrón inválido** (`mp-integrate/SKILL.md`)
- `/landing` produce 404 o redirects stale para la mayoría de productos.
- Fix: usa `/overview` como primera opción, `/landing` como fallback para productos que aún mantienen esa variante.

---

#### 🟠 High

**5. SmartApps sin indicación de contacto con equipo MP** (`mp-integrate/SKILL.md`)
- SmartApps es Assisted Portfolio — requiere acuerdo con MP antes de cualquier scaffolding.
- Fix: nota de bloqueo agregada en la sección `### smartapps`.

**6. URLs hardcodeadas en README** (`README.md`)
- 4 URLs con dominio `.com.ar` fijo en la sección Resources.
- Fix: reemplazadas por templates `{DOMAIN}/{LANG}` con ejemplos inline (AR, BR) y referencia a la tabla completa en `mp-integrate`.

---

### What's Correct (no changes needed)

- Arquitectura MCP-first documentada correctamente.
- Modo lock table del agente: `checkout-pro` → `preferences` únicamente, sin Orders API. ✅
- IPN explícitamente marcado como deprecated en `mp-webhooks`. ✅
- Modelo de testing moderno (`APP_USR-`) documentado correctamente, sin referencias a `TEST-`. ✅
- `sandbox_init_point` explícitamente prohibido. ✅
- `mp-review`: Payments API flaggeada como legacy (no blocker), con excepción para Checkout Pro. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)