### PR TITLE
docs: bump to v4.1.0 and refresh Vercel catalog + README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Mercado Pago Developer Experience"
   },
   "metadata": {
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "Public marketplace of Claude Code plugins for Mercado Pago payment integration development"
   },
   "plugins": [
@@ -12,7 +12,7 @@
       "name": "mercadopago",
       "source": "./plugins/mercadopago",
       "description": "Mercado Pago full-product integration toolkit. One agent routes to four orchestration skills (mp-integrate wizard, mp-webhooks, mp-test-setup, mp-review) that pull every endpoint, payload, and snippet live from the official Mercado Pago MCP server. The MCP must always be connected — there is no offline mode.",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "author": { "name": "Mercado Pago Developer Experience" },
       "repository": "https://github.com/mercadopago/mercadopago-claude-marketplace",
       "license": "Apache-2.0",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Status: Beta](https://img.shields.io/badge/status-beta-orange)](https://github.com/mercadopago/mercadopago-claude-marketplace)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
-[![Version: 4.0.0](https://img.shields.io/badge/version-4.0.0-green)](./CHANGELOG.md)
+[![Version: 4.1.0](https://img.shields.io/badge/version-4.1.0-green)](./CHANGELOG.md)
 [![Platform: Claude Code](https://img.shields.io/badge/platform-Claude%20Code-7c3aed)](https://claude.com/claude-code)
 [![CI](https://github.com/mercadopago/mercadopago-claude-marketplace/actions/workflows/validate.yml/badge.svg)](https://github.com/mercadopago/mercadopago-claude-marketplace/actions/workflows/validate.yml)
 
@@ -35,6 +35,15 @@ A Claude Code plugin that gives you an AI-powered integration assistant for the 
 - **Credential leak prevention** — hook scans every file write for hardcoded tokens
 - **OAuth-based auth** — connect via `/mp-connect`, no keychain scripts needed
 - **3 slash commands** — `/mp-integrate`, `/mp-review`, `/mp-connect`
+
+## What's new in v4.1.0
+
+A focused refinement of the v4.0.0 architecture. No breaking changes — same 4 skills, same MCP-first model.
+
+- **Bricks gotchas restored**: six experiential traps that v4.0.0 lost during the consolidation are back in `mp-integrate`'s Gotchas Bank — ad-blockers blocking `sdk.mercadopago.com`, debit cards without installments, `preferenceId` placeholder failures, Status Screen needing `payment_id` (not `order_id`), React `unmount()` in `useEffect` cleanup, and `back_urls` same-origin requirement.
+- **Implementation Report** in `/mp-review`: every review now ends with a structured closure block — Verified / Needs attention / Blockers / Next steps / Scores + Verdict — so developers know if they can ship.
+- **Orders API push reflected in reviews**: `mp-review` now detects legacy `/v1/payments` usage and surfaces a forward-looking migration item in *Needs attention* (not a blocker — existing code works, but the Payments API is being deprecated). Checkout Pro is explicitly exempted since it has no Orders API equivalent.
+- **Architecture-agnostic CI**: `validate.yml` no longer hardcodes skill filenames. Future refactors that keep the basic plugin structure won't break the build.
 
 ## Installation
 

--- a/docs/components.json
+++ b/docs/components.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-04-29T14:44:20.572413+00:00",
+  "generated_at": "2026-05-12T17:08:15.849155+00:00",
   "plugin": {
     "name": "mercadopago",
-    "version": "4.0.0",
+    "version": "4.1.0",
     "description": "Mercado Pago full-product integration toolkit. One agent routes to four orchestration skills (mp-integrate, mp-webhooks, mp-test-setup, mp-review) that pull live data from the official Mercado Pago MCP server. The MCP must always be connected — there is no offline mode.",
     "repository": "https://github.com/mercadopago/mercadopago-claude-marketplace",
     "license": "Apache-2.0",
@@ -35,7 +35,7 @@
       "name": "mp-integration-expert",
       "type": "agent",
       "description": "Use when implementing, reviewing, or debugging any Mercado Pago payment integration. Routes the request to one of four skills (mp-integrate, mp-webhooks, mp-test-setup, mp-review) and uses the Mercado Pago MCP server for live API data. The MCP must always be connected — there is no offline mode.",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "tags": [
         "payments",
         "mercadopago",
@@ -56,7 +56,7 @@
       "name": "mp-integrate",
       "type": "skill",
       "description": "Wizard that scaffolds a complete Mercado Pago integration for any product. Asks the developer the minimum questions needed (country, product, variant, SDK, mode), queries the MCP server for live docs, and produces a ready-to-paste code bundle. Use whenever the developer wants to add or migrate a Mercado Pago payment flow.",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "tags": [
         "mercadopago",
         "integration",
@@ -78,7 +78,7 @@
       "name": "mp-review",
       "type": "skill",
       "description": "Review a Mercado Pago integration against the official quality checklist and a fixed cross-cutting security checklist. Calls quality_checklist (and quality_evaluation when applicable) on the Mercado Pago MCP. Use after the integration is in place, or when /mp-review is invoked.",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "tags": [
         "mercadopago",
         "review",

--- a/plugins/mercadopago/.claude-plugin/plugin.json
+++ b/plugins/mercadopago/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mercadopago",
   "description": "Mercado Pago full-product integration toolkit. One agent routes to four orchestration skills (mp-integrate, mp-webhooks, mp-test-setup, mp-review) that pull live data from the official Mercado Pago MCP server. The MCP must always be connected — there is no offline mode.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": { "name": "Mercado Pago Developer Experience" },
   "repository": "https://github.com/mercadopago/mercadopago-claude-marketplace",
   "license": "Apache-2.0",

--- a/plugins/mercadopago/agents/mp-integration-expert.md
+++ b/plugins/mercadopago/agents/mp-integration-expert.md
@@ -7,7 +7,7 @@ tools: Read, Grep, Glob, Bash, WebFetch, AskUserQuestion, Write, Edit
 model: sonnet
 tags: [payments, mercadopago, checkout, webhooks, sdk, fintech, qr, subscriptions, marketplace]
 category: development
-version: 4.0.0
+version: 4.1.0
 ---
 
 # Mercado Pago Integration Expert


### PR DESCRIPTION
## Context

After v4.1.0 landed on `main`, the public-facing surfaces were still showing v4.0.0:

| Surface | Was | Should be |
|---|---|---|
| README badge | `4.0.0` | `4.1.0` |
| `plugin.json` | `4.0.0` | `4.1.0` |
| `marketplace.json` (both fields) | `4.0.0` | `4.1.0` |
| Agent version | `4.0.0` | `4.1.0` |
| Vercel catalog (`docs/components.json`) | generated `2026-04-29` against v4.0.0 | regenerated now |

This PR brings everything into alignment with v4.1.0.

## Changes

1. **Version bumps**: `plugin.json`, `marketplace.json` (metadata + plugin entry), and `mp-integration-expert.md` → `4.1.0`. `mp-test-setup` and `mp-webhooks` stay at `4.0.0` because they were not modified in v4.1.0.
2. **Vercel catalog regenerated**: `docs/components.json` rebuilt with `python3 scripts/generate_catalog.py`. Vercel auto-deploys from this file on push to `main`.
3. **README badge**: `4.0.0 → 4.1.0`.
4. **New "What's new in v4.1.0" section** in the README, summarising:
   - The 6 rescued Bricks gotchas in `mp-integrate`'s Gotchas Bank.
   - The mandatory Implementation Report block in `/mp-review`.
   - The Orders API migration item that `/mp-review` now surfaces when it detects legacy `/v1/payments` usage.
   - The architecture-agnostic CI workflow (no more hardcoded skill filenames).

## Verification

```bash
python3 -m json.tool .claude-plugin/marketplace.json > /dev/null
python3 -m json.tool plugins/mercadopago/.claude-plugin/plugin.json > /dev/null
python3 -m json.tool docs/components.json > /dev/null
python3 scripts/generate_catalog.py  # should be idempotent now
```

After merge, Vercel will re-deploy `mercadopago-claude-marketplace.vercel.app` showing v4.1.0 with the new components and versions.
