### PR TITLE
Gate credential hook on project relevance

### DIFF
--- a/plugins/mercadopago/hooks/validate_mp_credentials.py
+++ b/plugins/mercadopago/hooks/validate_mp_credentials.py
@@ -42,6 +42,61 @@ PATTERNS = {
 }
 
 
+# ---------- project relevance gate ----------
+
+# Dependency manifests checked for a "mercadopago" mention. Lock files are
+# intentionally excluded to keep the per-call file reads small.
+MANIFEST_FILES = (
+    "package.json",
+    "composer.json",
+    "requirements.txt",
+    "Pipfile",
+    "pyproject.toml",
+    "Gemfile",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "go.mod",
+)
+
+
+def _mentions_mercadopago(path: str) -> bool:
+    try:
+        with open(path, "r", errors="ignore") as f:
+            return "mercadopago" in f.read().lower()
+    except OSError:
+        return False
+
+
+def is_mercadopago_project(start_dir: str) -> bool:
+    """Heuristic check: does this project integrate with Mercado Pago?
+
+    Walks from start_dir up to the nearest .git boundary (or filesystem root)
+    looking for either:
+      - the plugin's per-project config (.claude/mercadopago.local.md), or
+      - a dependency manifest that mentions "mercadopago".
+
+    This is intentionally conservative: it only needs to be good enough to
+    keep the hook a no-op in projects that have nothing to do with Mercado
+    Pago. Maintainers: add or remove signals here as you see fit.
+    """
+    current = os.path.abspath(start_dir or os.getcwd())
+    for _ in range(32):  # bounded walk
+        if os.path.isfile(os.path.join(current, ".claude", "mercadopago.local.md")):
+            return True
+        for name in MANIFEST_FILES:
+            candidate = os.path.join(current, name)
+            if os.path.isfile(candidate) and _mentions_mercadopago(candidate):
+                return True
+
+        at_repo_root = os.path.isdir(os.path.join(current, ".git"))
+        parent = os.path.dirname(current)
+        if at_repo_root or parent == current:
+            break
+        current = parent
+    return False
+
+
 # ---------- helpers ----------
 
 def read_settings() -> dict:
@@ -119,6 +174,13 @@ def main():
         data = json.loads(sys.stdin.read())
     except (json.JSONDecodeError, EOFError):
         sys.exit(0)  # Can't parse input — allow
+
+    # Project relevance gate: if the current project shows no signs of a
+    # Mercado Pago integration, allow the tool call without inspection.
+    # This keeps the hook from changing tool behavior (e.g. blocking .env
+    # reads) in projects that have nothing to do with Mercado Pago.
+    if not is_mercadopago_project(os.getcwd()):
+        sys.exit(0)
 
     tool_name = data.get("tool_name", "")
     tool_input = data.get("tool_input", {})


### PR DESCRIPTION
## Why

This plugin is listed on the official Claude Code plugin marketplace (`anthropics/claude-plugins-official`). When the marketplace tried to bump its pin to the current `main`, its automated policy review flagged the `PreToolUse` hook:

- `hooks/hooks.json` registers `validate_mp_credentials.py` with matcher `Bash|Edit|Write|MultiEdit|Read`, so it runs on every matching tool call in **every** Claude Code session, regardless of whether the project uses Mercado Pago.
- The hook blocks `Read` of any `.env` / `.env.*` file in any project until a per-project `.claude/mercadopago.local.md` opt-out is created.
- Nothing in the install flow tells users that enabling the plugin changes tool behavior across all of their projects.

That global behavior is the only thing keeping the marketplace from picking up new versions of the plugin.

## What this does

Adds a small project-relevance gate at the top of `main()`. Before doing any inspection, the hook checks whether the current project looks like it uses Mercado Pago:

- the plugin's own per-project config exists (`.claude/mercadopago.local.md`), or
- a dependency manifest (`package.json`, `composer.json`, `requirements.txt`, `Pipfile`, `pyproject.toml`, `Gemfile`, `pom.xml`, `build.gradle`, `build.gradle.kts`, `go.mod`) at or above the cwd mentions `mercadopago`.

If neither is found, the hook exits 0 (allow) without touching the tool input. If either is found, the existing validation logic runs unchanged — the `.env` read block, the credential-pattern scan, and the `enabled: false` opt-out all behave exactly as before.

## Notes

- This is intentionally conservative and additive: ~60 added lines, no changes to `hooks.json`, no changes to the existing validation paths.
- Absent any Mercado Pago signal the hook is a no-op, so it cannot accidentally block work in unrelated projects.
- The detection heuristic is deliberately simple. You know your users' project layouts far better than I do — please feel free to tweak `MANIFEST_FILES` / `is_mercadopago_project()` to whatever set of signals best fits real MP integrations (e.g. `*.csproj`, env-var conventions, framework config files), or to gate only the `.env`-read behavior if you'd rather keep the credential scan unconditional.

## Testing

`python3 -m py_compile` passes, and a few stdin dry runs:

| project | tool call | result |
| --- | --- | --- |
| no MP signal | `Read .env` | allow (was: block) |
| no MP signal | `Write` containing an MP token | allow (gate short-circuits) |
| `package.json` depends on `mercadopago` | `Read .env` | block (unchanged) |
| `package.json` depends on `mercadopago` | `Write` containing an MP token | block (unchanged) |
| `.claude/mercadopago.local.md` present | `Read .env` | block (unchanged) |
| `.claude/mercadopago.local.md` with `enabled: false` | `Read .env` | allow (unchanged) |
| subdir of a project depending on `mercadopago` | `Read .env` | block (walk-up finds manifest) |
