### PR TITLE
ci: fix hook tests to work with project-relevance gate (unblocks PR #34)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,20 +41,24 @@ jobs:
 
       - name: Test hook blocks real token
         run: |
+          echo '{"dependencies":{"mercadopago":"^2.0.0"}}' > package.json
           RESULT=$(echo '{"tool_name":"Write","tool_input":{"file_path":"app.js","content":"const token = \"TEST-123456789012-123456-abc12345678901234567890123456789-U123456\""}}' \
             | python3 plugins/mercadopago/hooks/validate_mp_credentials.py; echo $?)
           if [ "$RESULT" != "2" ]; then
             echo "ERROR: Hook should have blocked real token (expected exit 2, got $RESULT)"
+          rm -f package.json
             exit 1
           fi
           echo "PASS: Hook correctly blocked real token"
 
       - name: Test hook allows env var reference
         run: |
+          echo '{"dependencies":{"mercadopago":"^2.0.0"}}' > package.json
           EXIT_CODE=$(echo '{"tool_name":"Write","tool_input":{"file_path":"app.js","content":"const token = process.env.MP_ACCESS_TOKEN"}}' \
             | python3 plugins/mercadopago/hooks/validate_mp_credentials.py; echo $?)
           if [ "$EXIT_CODE" != "0" ]; then
             echo "ERROR: Hook should have allowed env var reference (expected exit 0, got $EXIT_CODE)"
+          rm -f package.json
             exit 1
           fi
           echo "PASS: Hook correctly allowed env var reference"


### PR DESCRIPTION
## Context

PR #34 (from the Anthropic Claude Code marketplace team) adds a project-relevance gate to the credential validation hook. Without a Mercado Pago project signal in the environment, the hook now short-circuits to exit 0.

This breaks the CI tests in `validate.yml` that expect the hook to block a hardcoded token (exit 2). The runner has no `package.json` mentioning `mercadopago`, so the gate fires and the test fails.

## Fix

Create a minimal `package.json` before each hook test that lists `mercadopago` as a dependency, then remove it after the test. The gate now detects an MP project and the existing validation logic runs unchanged.

## Why this PR is separate

It only touches `.github/workflows/validate.yml` (+4 lines). Branched cleanly from `main` so no unrelated changes from other open PRs (#33 docs, #34 hook gate) are dragged in.

## Test plan

After merge:
- Re-run CI on PR #34. The `Test hook blocks real token` and `Test hook allows env var reference` steps should pass.
- Once PR #34 lands, the official Claude Code marketplace can pin this repo at the new version.