### PR TITLE
feat: apply golden rules — credential prefixes and Orders API availability

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our community a respectful and inclusive experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment of individuals or the company
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, as well as temporarily or permanently ban any contributor whose behavior is deemed inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and also when an individual is representing the project or its community in public spaces. Examples include using an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+This Code of Conduct also applies outside project spaces when there is a reasonable belief that an individual's behavior may have a negative impact on the project, the company, or the community.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by contacting the project maintainers. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html.
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq.

--- a/plugins/mercadopago/agents/mp-integration-expert.md
+++ b/plugins/mercadopago/agents/mp-integration-expert.md
@@ -97,7 +97,7 @@ Mode is **product-dependent**. Use the lock table below as a hard constraint whe
 | Product | The ONLY valid `mode` values | What to pass via `mode=` |
 |---------|------------------------------|--------------------------|
 | `checkout-pro` | `preferences` (the Orders API does **not** exist for Checkout Pro) | Always pass `mode=preferences`. Do not infer "orders" from anything. |
-| `checkout-api` | `orders`, `payments` | Pass `orders` for new code; `payments` only if existing code uses `/v1/payments`. |
+| `checkout-api` | `orders` | Always `orders` in ALL countries for card payments. |
 | `bricks` | `orders` | Always pass `mode=orders`. |
 | `qr` | `orders`, `legacy` | Pass `orders` for new; `legacy` if existing code calls `/qr` legacy endpoints. |
 | `point` | `orders`, `legacy` | Same as qr. |
@@ -106,6 +106,20 @@ Mode is **product-dependent**. Use the lock table below as a hard constraint whe
 | `subscriptions` / `money-out` / `smartapps` | n/a (their own APIs) | Do not pass `mode=`. |
 
 **If you find yourself about to set `mode=orders` for `product=checkout-pro`, abort.** The Orders API is not available for Checkout Pro today. Period.
+
+## ⭐ Golden Rule — Orders API availability by country
+
+Orders API is available in **all** countries. Always use `orders` as the default mode.
+
+| Country | Card payments (checkout-api, bricks) | Point availability | QR availability |
+|---------|--------------------------------------|-------------------|-----------------|
+| MLA, MLB, MLM | `orders` ✅ | ✅ Available | ✅ Available (MLM: QR not available) |
+| MLC | `orders` ✅ | ✅ Available | ✅ Available |
+| MCO | `orders` ✅ | ❌ Not available | ❌ Not available |
+| MPE | `orders` ✅ | ❌ Not available | ❌ Not available |
+| MLU | `orders` ✅ | ❌ Not available | ✅ Available |
+
+**Before recommending Point or QR**, always verify availability for the developer's country. Use Payments API as fallback only when the offline method is unavailable in that country.
 
 When the product allows more than one mode, infer the current mode from the codebase before asking:
 - `Grep` for `/v1/orders` / `order.create` → `orders`.
@@ -123,8 +137,11 @@ Hand control to the matched skill with the parameters you collected. Do **not** 
 - Test user credentials have the `APP_USR-` prefix (same as real production credentials)
 - To create test users: use the MCP tool `create_test_user` or the Developer Dashboard
 - To load balance into test users: use the MCP tool `add_money_test_user`
-- **Never suggest using credentials with `TEST-` prefix** — they are legacy and no longer issued
-- **Never ask if a credential is "sandbox" or "test" based on its prefix** — both test and production credentials start with `APP_USR-`
+- **Credential prefixes — two valid formats, both actively issued:**
+  - `APP_USR-`: Orders API, Checkout Pro, Point, QR Code, and apps created via MCP `create_application`
+  - `TEST-`: Checkout API / Payments API, Checkout Bricks, Subscriptions, and legacy integrations
+  - **Never tell a developer to change their credential prefix.** `get_credentials` always returns the correct format for the app's configured product.
+- **Never ask if a credential is "sandbox" or "test" based on its prefix** — the prefix alone does not tell them apart from production credentials
 - **How to obtain test credentials**: In the Developer Dashboard, navigate to *Tus integraciones > Datos de integracion > Credenciales* (right panel) > click **"Prueba"**. Alternative path: *Tus integraciones > Detalles de aplicacion > Pruebas > Credenciales de prueba*. For Brazil (Portuguese): *Suas integrações > Dados de integração > Credenciais* > click **"Teste"**.
 - **Checkout Pro testing**: Always use `init_point` (NOT `sandbox_init_point`) to redirect test users to the checkout. The `sandbox_init_point` parameter is deprecated and will be discontinued soon. For the complete test purchase flow, consult MCP (`search_documentation` with term "checkout pro test purchase").
 - **Environment setup guide**: Use `search_documentation` to find the environment setup guide for the specific product being integrated (e.g., search "configure environment {product}"). Do not hardcode a single product URL.

--- a/plugins/mercadopago/skills/mp-integrate/SKILL.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL.md
@@ -346,7 +346,7 @@ Get your credentials from the Mercado Pago Developer Dashboard:
 - For **testing**: click **"Prueba"** (or "Teste" in Brazil) to get test credentials.
 - For **production**: use the credentials in the **"Producción"** tab.
 
-Both test and production credentials use the `APP_USR-` prefix — there is no `TEST-` prefix anymore.
+Credentials come in two valid prefixes: `APP_USR-` (Orders API, Checkout Pro, Point, QR) and `TEST-` (Checkout API / Bricks / Payments API). Both are valid and actively issued. Never tell a developer to change their prefix — `get_credentials` returns the correct format automatically.
 
 Create `.env` from the template below (**never commit `.env`**):
 

--- a/plugins/mercadopago/skills/mp-test-setup/SKILL.md
+++ b/plugins/mercadopago/skills/mp-test-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mp-test-setup
-description: Create test users and add funds to them for Mercado Pago testing. Wraps create_test_user and add_money_test_user from the MCP. Clarifies that all credentials (including test users) use the APP_USR- prefix — there is no longer a TEST- sandbox.
+description: Create test users and add funds to them for Mercado Pago testing. Wraps create_test_user and add_money_test_user from the MCP. Clarifies that credentials come in APP_USR- (Orders API, Checkout Pro, Point, QR) and TEST- (Checkout API, Bricks, Payments API) formats — both are valid and actively issued.
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
@@ -12,15 +12,18 @@ metadata:
 
 # mp-test-setup
 
-This skill is the only place test users get created. It exists because the testing model is a frequent source of confusion (legacy docs still mention `TEST-` credentials that no longer exist).
+This skill is the only place test users get created. It exists because the testing model is a frequent source of confusion.
 
 ---
 
 ## The current testing model — read first
 
 - **There is no separate sandbox.** Tests run against the production API using the credentials of a **test user**.
-- **Test user credentials use the `APP_USR-` prefix**, exactly like real production credentials. There is no way to tell them apart by prefix.
-- The legacy `TEST-` prefix is **deprecated**. Never suggest it, never ask if a credential is "sandbox" by its prefix.
+- **Credential prefixes — two valid formats, both actively issued:**
+  - `APP_USR-`: Orders API, Checkout Pro, Point, QR Code, and test user credentials
+  - `TEST-`: Checkout API / Payments API, Checkout Bricks, Subscriptions
+  - **Never tell a developer to change their prefix.** `get_credentials` returns the correct format automatically.
+- **Never ask if a credential is "sandbox" by its prefix** — the prefix alone does not distinguish test from production.
 - A test user has its own balance (loaded via this skill) and behaves like any real account.
 - For automated test credentials without creating a test user: in the Developer Dashboard, *Tus integraciones → Datos de integración → Credenciales* → click **"Prueba"** (Brazilian Portuguese: *Suas integrações → Dados de integração → Credenciais → "Teste"*).
 


### PR DESCRIPTION
## Summary

Applies two new golden rules to the Mercado Pago Claude Code plugin:

**Golden Rule 1 — Credential prefix**
- Both `APP_USR-` and `TEST-` prefixes are valid and actively issued
- `APP_USR-`: Orders API, Checkout Pro, Point, QR Code
- `TEST-`: Checkout API, Bricks, Payments API, Subscriptions
- Plugin no longer tells developers to change their prefix
- `get_credentials` always returns the correct format automatically

**Golden Rule 2 — Orders API availability by country**
- Orders API is available in ALL countries
- `checkout-api` now always uses `orders` (removed country-based `payments` default)
- Added availability matrix for Point and QR by country:
  - Point not available: MCO, MPE, MLU
  - QR not available: MLM, MCO, MPE
- Payments API documented as fallback for offline methods only

## Files changed

- `agents/mp-integration-expert.md` — updated credential prefix docs, LOCK TABLE, added Golden Rule 2 table
- `skills/mp-integrate/SKILL.md` — updated credential line
- `skills/mp-test-setup/SKILL.md` — updated description and testing model section

## Test plan

- [ ] Verify TEST- prefix is no longer described as deprecated/invalid
- [ ] Verify checkout-api generates `orders` code for CL, CO, PE, UY
- [ ] Verify Point and QR availability warnings appear for restricted countries