### PR TITLE
fix: remove simulate_webhook and align credential prefix in README/mp-webhooks

### DIFF
--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -55,8 +55,8 @@ One agent, four skills, one MCP. The plugin is an **orchestrator**, not a docume
 | Skill | What it does | Backed by |
 |-------|--------------|-----------|
 | `mp-integrate` | Wizard that scaffolds a complete integration for any product (Checkout Pro, Checkout API, Bricks, QR, Point, Subscriptions, Marketplace, Wallet Connect, Money Out, SmartApps). Asks the minimum questions, queries the MCP, returns a ready-to-paste bundle. | `search_documentation` |
-| `mp-webhooks` | Receiver pattern with HMAC-SHA256 validation; configures, simulates, and diagnoses webhooks. | `save_webhook`, `simulate_webhook`, `notifications_history_diagnostics` |
-| `mp-test-setup` | Creates test users and loads funds. Clarifies the modern testing model (no `TEST-` prefix anymore — both production and test users use `APP_USR-`). | `create_test_user`, `add_money_test_user` |
+| `mp-webhooks` | Receiver pattern with HMAC-SHA256 validation; configures and diagnoses webhooks. | `save_webhook`, `notifications_history` |
+| `mp-test-setup` | Creates test users and loads funds. Credentials come in `APP_USR-` (Orders API, Checkout Pro, Point, QR) and `TEST-` (Checkout API, Bricks) formats — both valid. | `create_test_user`, `add_money_test_user` |
 | `mp-review` | Runs the official quality checklist live + a fixed cross-cutting security floor. Suggests `quality_evaluation` when the integration produced a compatible payment/order id. | `quality_checklist`, `quality_evaluation` |
 
 ## Commands

--- a/plugins/mercadopago/skills/mp-webhooks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-webhooks/SKILL.md
@@ -149,7 +149,7 @@ This shows which notifications were delivered, failed, or retried.
 ## Step 6 — Diagnose missed deliveries
 
 ```
-mcp__plugin_mercadopago_mcp__notifications_history_diagnostics()
+mcp__plugin_mercadopago_mcp__notifications_history()
 ```
 
 Returns delivery metrics and a breakdown of failures (timeouts, non-200 responses, signature mismatches). Use this when notifications are missing in production.

--- a/plugins/mercadopago/skills/mp-webhooks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-webhooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mp-webhooks
-description: Configure, simulate, and validate Mercado Pago webhooks. Wraps the MCP webhook tools (save_webhook, simulate_webhook, notifications_history_diagnostics) and provides the HMAC-SHA256 signature validation pattern that every receiver must implement. Use when adding, debugging, or hardening notification handling.
+description: Configure and validate Mercado Pago webhooks. Wraps the MCP webhook tools (save_webhook, notifications_history) and provides the HMAC-SHA256 signature validation pattern that every receiver must implement. Use when adding, debugging, or hardening notification handling.
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
@@ -33,11 +33,10 @@ Ask the developer (or infer from `$ARGUMENTS`) which of these they want:
 | Action | Tool to call | When |
 |--------|--------------|------|
 | Configure the webhook URL on the MP application | `save_webhook` | First time setup or rotating the endpoint |
-| Send a fake notification to your endpoint | `simulate_webhook` | Smoke test the receiver before going live |
-| Diagnose delivery failures | `notifications_history_diagnostics` | Investigating missed/failed notifications |
+| Diagnose delivery failures | `notifications_history` | Investigating missed/failed notifications |
 | Scaffold the receiver code | (no MCP call — render the pattern below) | Adding the receiver to the codebase |
 
-You may chain them: scaffold the receiver → `save_webhook` → `simulate_webhook` to verify end to end.
+You may chain them: scaffold the receiver → `save_webhook` → trigger a real test payment to verify end to end → use `notifications_history` to confirm delivery.
 
 ---
 
@@ -128,20 +127,22 @@ Confirm the response shows the URL and topics correctly registered.
 
 ---
 
-## Step 5 — Smoke test (`simulate_webhook`)
+## Step 5 — Smoke test (real test payment)
 
-Once the receiver is deployed (or running locally with a tunnel like `ngrok`):
+`simulate_webhook` no longer exists in the MCP. To test your receiver:
 
+1. Make a real payment using test credentials + test user + test card
+2. The webhook fires automatically when the payment status changes
+3. Verify your receiver returned `200` and processed the event
+
+To confirm delivery, use `notifications_history`:
 ```
-mcp__plugin_mercadopago_mcp__simulate_webhook(
-  topic="payment",
-  url_callback="https://<your-url>/mp/webhook",
-  resource_id="<a real test payment id>",
-  callback_env_production=false
+mcp__plugin_mercadopago_mcp__notifications_history(
+  application_id="<your_app_id>"
 )
 ```
 
-Verify the receiver returned `200` and that the event was processed (idempotent: re-run the same call and check no duplicate side effects).
+This shows which notifications were delivered, failed, or retried.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up fixes after PR #41 (golden rules) was merged:

- **Remove `simulate_webhook`** from `mp-webhooks/SKILL.md` — tool no longer exists in the MCP. Step 5 now guides developers to trigger a real test payment and use `notifications_history` to confirm delivery.
- **Rename `notifications_history_diagnostics` → `notifications_history`** — correct tool name in MCP.
- **Update README** — `mp-webhooks` description no longer lists `simulate_webhook`; `mp-test-setup` description now reflects both `APP_USR-` and `TEST-` as valid prefixes.

## Test plan
- [ ] `simulate_webhook` does not appear as a callable MCP tool in mp-webhooks
- [ ] `notifications_history` used consistently everywhere
- [ ] README descriptions accurate