### PR TITLE
fix: webhook HMAC validation + CODEOWNERS username typo (#50 review)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owner
-* @samhermeli @mminestrelli @luiquezada @Harievilozanini @ivillaverde @diegomarcuz @edsilvestrebento @melifelipub
+* @samhermeli @mminestrelli @luiquezada @Harievilozanini @ivillaverde @diegomarcuz @edsonsilvestrebento @melifelipub
 
 # Plugin-level ownership
-/plugins/mp-developer/ @samhermeli @mminestrelli @luiquezada @Harievilozanini @ivillaverde @diegomarcuz @edsilvestrebento @melifelipub
+/plugins/mp-developer/ @samhermeli @mminestrelli @luiquezada @Harievilozanini @ivillaverde @diegomarcuz @edsonsilvestrebento @melifelipub

--- a/plugins/mercadopago/skills/mp-integrate/SKILL-migrate.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL-migrate.md
@@ -157,6 +157,11 @@ fetch(`https://api.mercadopago.com/v1/orders/${data.id}`, ...)
 ```js
 // ✅ Required shape — always generate this exact structure
 app.post('/webhooks', (req, res) => {
+  // Validate MP signature BEFORE any processing (mirrors mp-webhooks HMAC pattern)
+  if (!verifyMpSignature(req, process.env.MP_WEBHOOK_SECRET)) {
+    return res.sendStatus(401);
+  }
+
   const { type, data } = req.body;
   const requestId = req.headers['x-request-id']; // unique per delivery from MP
 
@@ -185,6 +190,8 @@ app.post('/webhooks', (req, res) => {
   }
 });
 ```
+
+**`verifyMpSignature` implementation:** defer to `mp-webhooks/SKILL.md` for the canonical constant-time HMAC-SHA256 pattern. Do NOT inline a custom implementation — reference the skill and generate the same function it specifies. `MP_WEBHOOK_SECRET` must be present in `.env.example` (it already is — do not add it twice).
 - This applies to every file in the project, not just the main webhook handler.
 
 **Idempotency check:** if a file already contains `/v1/orders` → skip it and note: *"Already on Orders API."*


### PR DESCRIPTION
## Summary

Two fixes addressing review feedback on #50:

1. **🔴 Webhook handler missing HMAC validation** — the generated handler in `SKILL-migrate.md` processed incoming events without validating the `x-signature` header, allowing unauthenticated POST requests to trigger order fetches and status handling (CWE-345)
2. **🟠 CODEOWNERS username typo** — `@edsilvestrebento` corrected to `@edsonsilvestrebento`

## What changed — HMAC

Added `verifyMpSignature()` as the first step in the generated handler — before dedup, before ack, before any fetch. If the signature is invalid, returns `401` immediately. Implementation delegates to the canonical HMAC-SHA256 pattern in `mp-webhooks/SKILL.md` to avoid duplication. `MP_WEBHOOK_SECRET` was already present in `.env.example`.

## Before

```js
app.post('/webhooks', (req, res) => {
  const { type, data } = req.body;
  const requestId = req.headers['x-request-id'];
  if (processedEvents.has(requestId)) return res.sendStatus(200);
  // ... fetch and process
});
```

## After

```js
app.post('/webhooks', (req, res) => {
  if (!verifyMpSignature(req, process.env.MP_WEBHOOK_SECRET)) {
    return res.sendStatus(401);
  }
  const { type, data } = req.body;
  // ... rest unchanged
});
```

## Test plan

- [ ] Verify generated webhook handler includes `verifyMpSignature()` as first step
- [ ] Verify unauthenticated POST to `/webhooks` returns `401`
- [ ] Verify CODEOWNERS resolves both `@edsonsilvestrebento` and `@melifelipub` as valid GitHub users
