### PR TITLE
fix: 6 security and consistency bugs in hook and skills

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -45,8 +45,8 @@ jobs:
           # Build token at runtime to avoid secret-scanning false positives on the literal.
           # Format: (TEST|APP_USR)-{12+digits}-{6digits}-{32hex}-{digits} — no U prefix.
           PREFIX="TEST"
-          HASH="abc12345678901234567890123456789"  # 32 hex chars
-          TOKEN="${PREFIX}-123456789012-123456-${HASH}0-987654321"
+          HASH="abc1234567890123456789012345678a"  # exactly 32 hex chars
+          TOKEN="${PREFIX}-123456789012-123456-${HASH}-987654321"
           RESULT=$(echo "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"app.js\",\"content\":\"const token = \\\"${TOKEN}\\\"\"}}" \
             | python3 plugins/mercadopago/hooks/validate_mp_credentials.py; echo $?)
           if [ "$RESULT" != "2" ]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,11 +42,16 @@ jobs:
       - name: Test hook blocks real token
         run: |
           echo '{"dependencies":{"mercadopago":"^2.0.0"}}' > package.json
-          RESULT=$(echo '{"tool_name":"Write","tool_input":{"file_path":"app.js","content":"const token = \"TEST-123456789012-123456-abc12345678901234567890123456789-U123456\""}}' \
+          # Build token at runtime to avoid secret-scanning false positives on the literal.
+          # Format: (TEST|APP_USR)-{12+digits}-{6digits}-{32hex}-{digits} — no U prefix.
+          PREFIX="TEST"
+          HASH="abc12345678901234567890123456789"  # 32 hex chars
+          TOKEN="${PREFIX}-123456789012-123456-${HASH}0-987654321"
+          RESULT=$(echo "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"app.js\",\"content\":\"const token = \\\"${TOKEN}\\\"\"}}" \
             | python3 plugins/mercadopago/hooks/validate_mp_credentials.py; echo $?)
           if [ "$RESULT" != "2" ]; then
             echo "ERROR: Hook should have blocked real token (expected exit 2, got $RESULT)"
-          rm -f package.json
+            rm -f package.json
             exit 1
           fi
           echo "PASS: Hook correctly blocked real token"

--- a/docs/components.json
+++ b/docs/components.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T12:49:05.727013+00:00",
+  "generated_at": "2026-08-06T16:11:19.076687+00:00",
   "plugin": {
     "name": "mercadopago",
     "version": "4.3.0",
@@ -198,7 +198,7 @@
       "type": "hook",
       "description": "Mercado Pago developer plugin hooks",
       "trigger": "PreToolUse",
-      "matcher": "Bash|Edit|Write|MultiEdit|Read",
+      "matcher": "Bash|Edit|Write|MultiEdit|Read|NotebookEdit",
       "hook_type": "command",
       "path": "plugins/mercadopago/hooks/hooks.json"
     }

--- a/docs/components.json
+++ b/docs/components.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T16:11:19.076687+00:00",
+  "generated_at": "2026-08-06T16:28:06.439528+00:00",
   "plugin": {
     "name": "mercadopago",
     "version": "4.3.0",

--- a/plugins/mercadopago/commands/mp-integrate.md
+++ b/plugins/mercadopago/commands/mp-integrate.md
@@ -14,12 +14,12 @@ This command runs the Mercado Pago integration wizard. **Do not re-read this fil
 
 Inspect `$ARGUMENTS`:
 
-| `$ARGUMENTS` starts with | Skill to follow |
+| `$ARGUMENTS` starts with | Skill file (resolve path via `find` — see Rule 2) |
 |--------------------------|-----------------|
-| `webhook` | Read and follow the SKILL.md at `~/.claude/plugins/cache/claude-plugins-official/mercadopago/{version}/skills/mp-webhooks/SKILL.md` |
-| `test-setup` | Read and follow `~/.claude/plugins/cache/claude-plugins-official/mercadopago/{version}/skills/mp-test-setup/SKILL.md` |
-| `migrate` | Read and follow `~/.claude/plugins/cache/claude-plugins-official/mercadopago/{version}/skills/mp-integrate/SKILL-migrate.md` |
-| anything else (or empty) | Read and follow `~/.claude/plugins/cache/claude-plugins-official/mercadopago/{version}/skills/mp-integrate/SKILL.md` |
+| `webhook` | `*mercadopago*/skills/mp-webhooks/SKILL.md` |
+| `test-setup` | `*mercadopago*/skills/mp-test-setup/SKILL.md` |
+| `migrate` | `*mercadopago*/skills/mp-integrate/SKILL-migrate.md` |
+| anything else (or empty) | `*mercadopago*/skills/mp-integrate/SKILL.md` |
 
 ## Execution rules
 
@@ -165,10 +165,17 @@ Inspect `$ARGUMENTS`:
      > Continuing — use test credentials before running any payment.
      Save `credential_type=unknown` to `.mp-integrate-progress.md`.
 
-2. **Read the SKILL.md ONCE.** Use the `Read` tool with the relative path from the routing table. If the file is not found in the current project (path does not exist), run via `Bash` to locate it in the plugin cache:
-   Use the **Read tool** (not Bash) with this path:
-   `~/.claude/plugins/cache/claude-plugins-official/mercadopago/{version}/skills/mp-integrate/SKILL.md`
-   Then `Read` the absolute path returned. Once loaded, **execute the steps starting from Step 1.a** (auto-detect SDK/client/mode) — skip Pre-flight, Step 0, and Step 0.b, which already ran in Steps 1.1–1.4 above. Do not re-read the SKILL.md or this command file again. Do not delegate to a separate agent.
+2. **Read the SKILL.md ONCE.** Use the routing table to pick the right file, then locate it via `Bash`:
+
+   ```bash
+   find ~/.claude/plugins/cache -path "*mercadopago*/skills/mp-integrate/SKILL.md" 2>/dev/null | sort -V | tail -1
+   # For webhook route:  find ~/.claude/plugins/cache -path "*mercadopago*/skills/mp-webhooks/SKILL.md" 2>/dev/null | sort -V | tail -1
+   # For test-setup:     find ~/.claude/plugins/cache -path "*mercadopago*/skills/mp-test-setup/SKILL.md" 2>/dev/null | sort -V | tail -1
+   # For migrate:        find ~/.claude/plugins/cache -path "*mercadopago*/skills/mp-integrate/SKILL-migrate.md" 2>/dev/null | sort -V | tail -1
+   # Windows (PowerShell): Get-ChildItem "$env:APPDATA\Claude\plugins" -Recurse -Filter "SKILL.md" | Where-Object { $_.FullName -like "*mp-integrate*" } | Sort-Object FullName | Select-Object -Last 1 -ExpandProperty FullName
+   ```
+
+   Use the `Read` tool with the absolute path returned. Once loaded, **execute the steps starting from Step 1.a** (auto-detect SDK/client/mode) — skip Pre-flight, Step 0, and Step 0.b, which already ran in Steps 1.1–1.4 above. Do not re-read the SKILL.md or this command file again. Do not delegate to a separate agent.
 
 3. **Apply the HARD LOCKS at the top of the SKILL.md before any `AskUserQuestion`.** In particular: SDK is never asked, `mode` for `checkout-pro` is `preferences` (Orders is not available — never offer it), and there is no `Environment` picker.
 

--- a/plugins/mercadopago/hooks/hooks.json
+++ b/plugins/mercadopago/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash|Edit|Write|MultiEdit|Read",
+        "matcher": "Bash|Edit|Write|MultiEdit|Read|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/plugins/mercadopago/hooks/validate_mp_credentials.py
+++ b/plugins/mercadopago/hooks/validate_mp_credentials.py
@@ -27,7 +27,7 @@ import sys
 
 PATTERNS = {
     "MP Access Token": re.compile(
-        r"(TEST|APP_USR)-\d{12,}-\d{6}-[a-f0-9]{32}-U\d+"
+        r"(TEST|APP_USR)-\d{12,}-\d{6}-[a-f0-9]{32}-\d+"
     ),
     "Client Secret": re.compile(
         r"""['"]client_secret['"]\s*[:=]\s*['"][a-f0-9]{32,}['"]"""
@@ -160,21 +160,26 @@ def scan(text: str) -> list[tuple[str, str]]:
 
 
 def is_env_file(path: str) -> bool:
-    """Check if path is a .env file (not .env.example) within the project root."""
+    """Check if path is a .env secrets file (not .env.example or code like .env.ts)."""
     basename = os.path.basename(path)
+    # Allowlist of known env-var file suffixes — anything else (e.g. .env.ts) is code
+    _ALLOWED = {".env", ".env.local", ".env.development", ".env.production", ".env.test",
+                ".env.development.local", ".env.production.local", ".env.test.local"}
     if basename == ".env.example" or basename.endswith(".env.example"):
         return False
-    if not (basename == ".env" or basename.startswith(".env.")):
+    if basename not in _ALLOWED:
         return False
-    # Ensure the file is within the current working directory (prevent path traversal)
+    return True
+
+
+def is_within_project(path: str) -> bool:
+    """Return True if path resolves to a location inside the current working directory."""
     try:
         abs_path = os.path.realpath(os.path.abspath(path))
         project_root = os.path.realpath(os.getcwd())
-        if not abs_path.startswith(project_root + os.sep) and abs_path != project_root:
-            return False
+        return abs_path.startswith(project_root + os.sep) or abs_path == project_root
     except (OSError, ValueError):
         return False
-    return True
 
 
 # ---------- main ----------
@@ -202,7 +207,7 @@ def main():
 
     file_path = get_file_path(tool_name, tool_input)
 
-    # --- Read tool path: block .env reads (not .env.example) ---
+    # --- Read tool path: block .env reads (not .env.example), inside OR outside project ---
     if tool_name == "Read":
         if file_path and is_env_file(file_path):
             print(
@@ -215,8 +220,9 @@ def main():
 
     # --- Write/Edit/MultiEdit/Bash path: scan for credentials ---
 
-    # Skip .env files — credentials belong there
-    if file_path and is_env_file(file_path):
+    # Skip .env files that are inside the project — credentials belong there.
+    # Files outside the project root are still scanned (no reason to skip them).
+    if file_path and is_env_file(file_path) and is_within_project(file_path):
         sys.exit(0)
 
     # Extract and scan

--- a/plugins/mercadopago/hooks/validate_mp_credentials.py
+++ b/plugins/mercadopago/hooks/validate_mp_credentials.py
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 Mercado Pago Plugin — Credential Leak Prevention Hook
 
-Scans tool inputs (Bash, Edit, Write, MultiEdit, Read) for hardcoded
+Scans tool inputs (Bash, Edit, Write, MultiEdit, NotebookEdit, Read) for hardcoded
 Mercado Pago credentials and blocks them before they reach source files.
 Also blocks reading .env files to prevent credential exposure.
 
@@ -140,6 +140,8 @@ def extract_text(tool_name: str, tool_input: dict) -> str:
         # MultiEdit contains an array of edits
         edits = tool_input.get("edits", [])
         return "\n".join(e.get("new_string", "") for e in edits)
+    elif tool_name == "NotebookEdit":
+        return tool_input.get("cell_source", "")
     return ""
 
 
@@ -147,6 +149,8 @@ def get_file_path(tool_name: str, tool_input: dict) -> str:
     """Extract the target file path from a tool input."""
     if tool_name in ("Write", "Edit", "MultiEdit", "Read"):
         return tool_input.get("file_path", "")
+    if tool_name == "NotebookEdit":
+        return tool_input.get("notebook_path", "")
     return ""
 
 

--- a/plugins/mercadopago/skills/mp-integrate/SKILL-migrate.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL-migrate.md
@@ -155,15 +155,27 @@ fetch(`https://api.mercadopago.com/v1/orders/${data.id}`, ...)
 - **`orderStore.delete` on terminal statuses** — call `orderStore.delete(external_reference)` for `canceled`, `expired`, and `refunded`. Omitting it leaves orphan entries in memory indefinitely.
 
 ```js
+import crypto from 'node:crypto';
+
 // ✅ Required shape — always generate this exact structure
 app.post('/webhooks', (req, res) => {
-  // Validate MP signature BEFORE any processing (mirrors mp-webhooks HMAC pattern)
-  if (!verifyMpSignature(req, process.env.MP_WEBHOOK_SECRET)) {
-    return res.sendStatus(401);
-  }
+  // HMAC-SHA256 signature validation (canonical pattern from mp-webhooks)
+  const signature = req.header('x-signature') ?? '';
+  const requestId = req.header('x-request-id') ?? '';
+  const parts = Object.fromEntries(
+    signature.split(',').map((p) => p.split('=').map((s) => s.trim()))
+  );
+  const ts = parts.ts;
+  const v1 = parts.v1;
+  const dataId = req.body?.data?.id;
+  if (!ts || !v1 || !dataId || !requestId) return res.status(400).end();
+  const canonical = `id:${dataId};request-id:${requestId};ts:${ts};`;
+  const expected = crypto.createHmac('sha256', process.env.MP_WEBHOOK_SECRET).update(canonical).digest('hex');
+  const valid = expected.length === v1.length &&
+                crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(v1));
+  if (!valid) return res.status(401).end();
 
   const { type, data } = req.body;
-  const requestId = req.headers['x-request-id']; // unique per delivery from MP
 
   // Dedup by requestId — NOT by type:data.id (would discard refund after payment)
   if (processedEvents.has(requestId)) return res.sendStatus(200);
@@ -190,8 +202,6 @@ app.post('/webhooks', (req, res) => {
   }
 });
 ```
-
-**`verifyMpSignature` implementation:** defer to `mp-webhooks/SKILL.md` for the canonical constant-time HMAC-SHA256 pattern. Do NOT inline a custom implementation — reference the skill and generate the same function it specifies. `MP_WEBHOOK_SECRET` must be present in `.env.example` (it already is — do not add it twice).
 - This applies to every file in the project, not just the main webhook handler.
 
 **Idempotency check:** if a file already contains `/v1/orders` → skip it and note: *"Already on Orders API."*

--- a/plugins/mercadopago/skills/mp-integrate/SKILL.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL.md
@@ -541,7 +541,7 @@ Immediately after rendering the bundle, **before listing next steps**, call `Ask
 1. **Install the SDK** — run `npm install mercadopago` (or the equivalent for the detected SDK) in the directory that contains the server-side manifest. Report any non-zero exit code and stop.
 2. **Write the server snippet** — create or edit the server file (e.g., `backend/index.js`, `backend/src/routes/mercadopago.js`) inserting the snippet from Step 4. If the file already exists, inject the new route after existing routes rather than overwriting.
 3. **Write the client component** — create `frontend/src/components/CheckoutButton.{jsx|tsx|vue|…}` (or the framework-appropriate path/extension) with the client snippet from Step 4. If the file already exists, warn and ask the developer before overwriting.
-4. **Create `.env.example`** — write the template vars (MP_ACCESS_TOKEN, MP_PUBLIC_KEY, MP_WEBHOOK_SECRET, APP_URL) to `.env.example`. Never touch or create `.env` directly — the developer must fill in their credentials.
+4. **Create `.env.example`** — write the template vars (MP_ACCESS_TOKEN, MP_PUBLIC_KEY, MP_WEBHOOK_SECRET, APP_URL) to `.env.example`. Only create `.env` with real values if credentials were already fetched via `get_credentials` in Step 0.b (State A) — in that case `.env` already exists; do NOT overwrite it. In State B (no MCP), never create `.env` — the developer must fill in their own credentials.
 5. **Update `.gitignore`** — add `.env`, `.env.*.local`, `.mp-integrate-progress.md` if not already present.
 6. After all writes, print a short summary:
 

--- a/plugins/mercadopago/skills/mp-webhooks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-webhooks/SKILL.md
@@ -151,7 +151,7 @@ If a topic is not in this table, query MCP for the latest list rather than guess
 ```
 mcp__plugin_mercadopago_mcp__save_webhook(
   callback="https://<production-url>/mp/webhook",
-  callback_sandbox="https://<staging-url>/mp/webhook",
+  callback_url="https://<your-domain>/mp/webhook",
   topics=["payment", "merchant_order", ...]
 )
 ```


### PR DESCRIPTION
## Bugs fixed

### 🔴 CRÍTICO — Regex do token não pegava credencial real
`hooks/validate_mp_credentials.py:30` — regex exigia `-U\d+` no final mas tokens reais terminam só em dígitos (sem prefixo U). Qualquer token real passava sem bloqueio. CI test corrigido para construir o token em runtime no formato correto.

### 🟠 ALTO — `verifyMpSignature` chamada sem estar definida
`SKILL-migrate.md` — handler gerado chamava `verifyMpSignature(req, secret)` que não existe. Substituído pelo bloco HMAC-SHA256 inline do padrão canônico de `mp-webhooks/SKILL.md` (`crypto.timingSafeEqual`).

### 🟠 ALTO — Contradição no comportamento do `.env`
`SKILL.md:544` dizia "never touch or create `.env`" mas `mp-integrate.md:111` e `SKILL.md:558-559` mandavam criar com valores reais no State A. Linha 544 corrigida para refletir a lógica State A/B correta.

### 🟡 MÉDIO — Lacunas de cobertura do hook
- `NotebookEdit` adicionado ao matcher em `hooks.json`
- `is_env_file` restrito a allowlist explícita (`.env`, `.env.local`, `.env.{development,production,test}[.local]`) — `.env.ts` e similares não são mais tratados como env files

### 🟡 MÉDIO — `.env` fora do projeto passava no Read sem bloqueio
`is_env_file` e `is_within_project` separados — leitura de `.env` fora do `cwd` (ex: `../../outro-projeto/.env`) agora é bloqueada corretamente.

### 🟢 BAIXO — `callback_sandbox` em `mp-webhooks`
Referência ao sandbox removido substituída por `callback_url`.
