### PR TITLE
fix(dependabot): prevent supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: monday
     commit-message:
       prefix: "ci"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
**TL;DR:** add cooldown period to prevent dependabot PRs with poisoned package updates.

## Problem

By default, Dependabot sets `cooldown` to 3 days, but this is not enough to mitigate the risk of supply chain attacks reported by [Zizmor](https://docs.zizmor.sh).

> Check out the [Zizmor audit rule](https://docs.zizmor.sh/audits/#dependabot-cooldown) for more information and related articles.

## Solution

To prevent supply chain attacks and reduce the risk of introducing unexpected Breaking Changes that have not yet been reported to the dependency maintainers, this pull request configure a default cooldown of 7 days for each dependency updates.