### PR TITLE
fix: hooks no longer invoke python3 directly on Windows (AppXSvc leak, #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Hooks no longer invoke `python3` directly. On Windows, a bare `python3` almost always resolves to the Microsoft Store's execution-alias stub (a 0-byte binary), and every invocation leaked handles and commit charge in the AppXSvc service with no self-cleanup — `check-version.sh` (every `UserPromptSubmit`) and the credential-scan `PreToolUse` hook (nearly every tool call) combined to leak tens of GB of committed memory within a normal session on affected machines. `check-version.sh` now reads the version field with `grep`/`sed` instead of spawning an interpreter; the credential-scan hook now resolves a real Python via a Windows-aware helper (`resolve-python.sh`) before running, falling back to its previous no-op behavior if none is found.
+
 ## [4.3.1] - 2026-08-21
 
 ### Added

--- a/plugins/mercadopago/hooks/check-version.sh
+++ b/plugins/mercadopago/hooks/check-version.sh
@@ -15,7 +15,7 @@ PLUGIN_DATA="${CLAUDE_PLUGIN_DATA:-}"
 VERSION_FILE="$PLUGIN_ROOT/.claude-plugin/plugin.json"
 [[ -f "$VERSION_FILE" ]] || exit 0
 
-current=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['version'])" "$VERSION_FILE" 2>/dev/null) || exit 0
+current=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' "$VERSION_FILE" | head -1 | sed -E 's/.*"([^"]+)"$/\1/') || exit 0
 [[ -z "$current" ]] && exit 0
 
 SEEN_DIR="$PLUGIN_DATA"

--- a/plugins/mercadopago/hooks/hooks.json
+++ b/plugins/mercadopago/hooks/hooks.json
@@ -19,8 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/validate_mp_credentials.py"],
+            "command": "bash",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/run-credential-check.sh"],
             "timeout": 10
           }
         ]

--- a/plugins/mercadopago/hooks/resolve-python.sh
+++ b/plugins/mercadopago/hooks/resolve-python.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Resolves a working Python 3 interpreter, explicitly rejecting the
+# Microsoft Store execution-alias stub on Windows.
+#
+# On Windows, a bare `python3` (and often `python`) resolves to a 0-byte
+# binary under `%LOCALAPPDATA%\Microsoft\WindowsApps\` unless a real
+# interpreter is installed and ordered earlier on PATH. Invoking that stub
+# triggers an AppX deployment-service operation that leaks handles and
+# commit charge in the AppXSvc Windows service on every call, with no
+# self-cleanup — see #64 for the full investigation.
+#
+# Usage:
+#   PY="$(resolve-python.sh)" || exit 0   # no real interpreter found
+#   "$PY" some_script.py
+#
+# Prints the resolved interpreter's absolute path to stdout and exits 0,
+# or exits 1 with no output if no real interpreter is found.
+
+set -uo pipefail
+
+for candidate in python3 python py; do
+  resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+  [ -n "$resolved" ] || continue
+  case "$resolved" in
+    *WindowsApps*|*windowsapps*) continue ;;  # Store execution-alias stub
+  esac
+  [ -s "$resolved" ] || continue  # 0-byte stub, belt-and-suspenders
+  printf '%s\n' "$resolved"
+  exit 0
+done
+
+exit 1

--- a/plugins/mercadopago/hooks/resolve-python.sh
+++ b/plugins/mercadopago/hooks/resolve-python.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 #
 # Resolves a working Python 3 interpreter, explicitly rejecting the
-# Microsoft Store execution-alias stub on Windows.
+# Microsoft Store execution-alias stub on Windows and any candidate that
+# doesn't actually run as Python 3 (a zero-byte stub, a non-Python
+# executable, or the `py` launcher defaulting to a Python 2 install).
 #
 # On Windows, a bare `python3` (and often `python`) resolves to a 0-byte
 # binary under `%LOCALAPPDATA%\Microsoft\WindowsApps\` unless a real
@@ -10,14 +12,28 @@
 # commit charge in the AppXSvc Windows service on every call, with no
 # self-cleanup — see #64 for the full investigation.
 #
-# Usage:
-#   PY="$(resolve-python.sh)" || exit 0   # no real interpreter found
-#   "$PY" some_script.py
+# The `py` launcher is never trusted at its default: without an explicit
+# `-3`, it can resolve to a Python 2 install depending on what's on the
+# machine and how py.ini is configured. It is therefore always both
+# verified and invoked with `-3`.
 #
-# Prints the resolved interpreter's absolute path to stdout and exits 0,
-# or exits 1 with no output if no real interpreter is found.
+# Usage:
+#   out="$(mktemp)"; bash resolve-python.sh > "$out" || { rm -f "$out"; exit 0; }
+#   mapfile -d '' -t PY_ARGV < "$out"; rm -f "$out"
+#   [ "${#PY_ARGV[@]}" -gt 0 ] || exit 0   # no working Python 3 found
+#   "${PY_ARGV[@]}" some_script.py
+#
+# Prints the resolved command as a NUL-separated argv (interpreter path,
+# plus a trailing `-3` when the `py` launcher is the resolved candidate)
+# and exits 0, or exits 1 with no output if no working Python 3
+# interpreter is found.
 
 set -uo pipefail
+
+is_python3() {
+  # "$@" is the candidate invocation (path, plus any flags e.g. -3)
+  "$@" -c 'import sys; sys.exit(0 if sys.version_info[0] == 3 else 1)' >/dev/null 2>&1
+}
 
 for candidate in python3 python py; do
   resolved="$(command -v "$candidate" 2>/dev/null)" || continue
@@ -26,7 +42,17 @@ for candidate in python3 python py; do
     *WindowsApps*|*windowsapps*) continue ;;  # Store execution-alias stub
   esac
   [ -s "$resolved" ] || continue  # 0-byte stub, belt-and-suspenders
-  printf '%s\n' "$resolved"
+
+  if [ "$candidate" = "py" ]; then
+    # The launcher can default to Python 2 depending on what's installed
+    # and how py.ini is configured — never trust it without -3.
+    is_python3 "$resolved" -3 || continue
+    printf '%s\0%s\0' "$resolved" "-3"
+    exit 0
+  fi
+
+  is_python3 "$resolved" || continue
+  printf '%s\0' "$resolved"
   exit 0
 done
 

--- a/plugins/mercadopago/hooks/run-credential-check.sh
+++ b/plugins/mercadopago/hooks/run-credential-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Wrapper for validate_mp_credentials.py: resolves a real Python interpreter
+# via resolve-python.sh before running it, instead of trusting a bare
+# `python3` invoked directly from hooks.json (see #64 — that resolves to the
+# Microsoft Store execution-alias stub on Windows and leaks handles/commit
+# charge in the AppXSvc service on every PreToolUse call).
+#
+# Fails open (exit 0, same as the previous behavior when the Store stub
+# silently did nothing useful) if no real interpreter is found, so this
+# change never makes the hook more restrictive than it already was.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PY="$(bash "$SCRIPT_DIR/resolve-python.sh")" || exit 0
+
+exec "$PY" "$SCRIPT_DIR/validate_mp_credentials.py" "$@"

--- a/plugins/mercadopago/hooks/run-credential-check.sh
+++ b/plugins/mercadopago/hooks/run-credential-check.sh
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
 #
-# Wrapper for validate_mp_credentials.py: resolves a real Python interpreter
-# via resolve-python.sh before running it, instead of trusting a bare
-# `python3` invoked directly from hooks.json (see #64 — that resolves to the
-# Microsoft Store execution-alias stub on Windows and leaks handles/commit
-# charge in the AppXSvc service on every PreToolUse call).
+# Wrapper for validate_mp_credentials.py: resolves a real Python 3
+# interpreter via resolve-python.sh before running it, instead of trusting
+# a bare `python3` invoked directly from hooks.json (see #64 — that
+# resolves to the Microsoft Store execution-alias stub on Windows and
+# leaks handles/commit charge in the AppXSvc service on every PreToolUse
+# call).
 #
 # Fails open (exit 0, same as the previous behavior when the Store stub
-# silently did nothing useful) if no real interpreter is found, so this
-# change never makes the hook more restrictive than it already was.
+# silently did nothing useful) if no working Python 3 interpreter is
+# found, so this change never makes the hook more restrictive than it
+# already was.
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-PY="$(bash "$SCRIPT_DIR/resolve-python.sh")" || exit 0
+resolved_out="$(mktemp)"
+trap 'rm -f "$resolved_out"' EXIT
 
-exec "$PY" "$SCRIPT_DIR/validate_mp_credentials.py" "$@"
+bash "$SCRIPT_DIR/resolve-python.sh" > "$resolved_out" || exit 0
+
+PY_ARGV=()
+mapfile -d '' -t PY_ARGV < "$resolved_out"
+[ "${#PY_ARGV[@]}" -gt 0 ] || exit 0
+
+exec "${PY_ARGV[@]}" "$SCRIPT_DIR/validate_mp_credentials.py" "$@"

--- a/plugins/mercadopago/hooks/test-resolve-python.sh
+++ b/plugins/mercadopago/hooks/test-resolve-python.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# Deterministic regression tests for resolve-python.sh and its wrapper
+# run-credential-check.sh. Every scenario builds fake `python3`/`python`/
+# `py` executables on an isolated, throwaway PATH, so results never depend
+# on what is actually installed on the machine running the suite.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="$SCRIPT_DIR/resolve-python.sh"
+WRAPPER="$SCRIPT_DIR/run-credential-check.sh"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Resolved once, from the *current* PATH, before any scenario narrows PATH
+# down to a fake directory. Every fake interpreter is shebanged with this
+# absolute path (instead of `#!/usr/bin/env bash`) so it stays executable
+# once PATH no longer contains a real bash — exactly the situation each
+# scenario below is testing resolve-python.sh under.
+REAL_BASH="$(command -v bash)"
+REAL_BASH_DIR="$(dirname "$REAL_BASH")"
+
+failures=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+pass() {
+  echo "PASS: $1"
+}
+
+# Writes an executable bash stub at "$1" with body "$2".
+write_stub() {
+  local target="$1" body="$2"
+  mkdir -p "$(dirname "$target")"
+  {
+    printf '#!%s\n' "$REAL_BASH"
+    printf '%s\n' "$body"
+  } > "$target"
+  chmod +x "$target"
+}
+
+# A stub that behaves like a real Python 3 interpreter: succeeds on the
+# resolver's `-c "import sys; ..."` version probe, and otherwise records
+# how it was invoked to $MARKER_FILE (used by the wrapper end-to-end
+# checks below).
+python3_stub_body='
+if [ "$1" = "-c" ]; then
+  exit 0
+fi
+printf "invoked:%s\n" "$*" >> "$MARKER_FILE"
+exit 0
+'
+
+# A stub that behaves like the `py` launcher: only succeeds when called
+# with -3 first, exactly like the real fix requires.
+py_stub_supports_py3_body='
+if [ "$1" != "-3" ]; then
+  exit 1
+fi
+shift
+if [ "$1" = "-c" ]; then
+  exit 0
+fi
+printf "invoked:-3 %s\n" "$*" >> "$MARKER_FILE"
+exit 0
+'
+
+# A `py` launcher with no Python 3 registered at all: -3 fails too.
+py_stub_no_py3_body='
+exit 1
+'
+
+# A stub that is executable but is not a Python interpreter at all (or is
+# otherwise broken): every invocation, including the version probe, fails.
+non_python_stub_body='
+exit 1
+'
+
+# Runs the resolver with PATH replaced by "$1", capturing its NUL-separated
+# argv into the global PY_ARGV array and its exit code into RC.
+run_resolver() {
+  local fake_path="$1"
+  local out="$TMP_ROOT/resolver-out-$$-$RANDOM"
+  PATH="$fake_path" "$REAL_BASH" "$RESOLVER" > "$out"
+  RC=$?
+  PY_ARGV=()
+  mapfile -d '' -t PY_ARGV < "$out"
+  rm -f "$out"
+}
+
+# --- Scenario 1: a valid Python 3 interpreter -------------------------------
+scenario1_dir="$TMP_ROOT/scenario1/bin"
+export MARKER_FILE="$TMP_ROOT/scenario1/marker"
+write_stub "$scenario1_dir/python3" "$python3_stub_body"
+run_resolver "$scenario1_dir"
+if [ "$RC" -eq 0 ] && [ "${#PY_ARGV[@]}" -eq 1 ] && [ "${PY_ARGV[0]}" = "$scenario1_dir/python3" ]; then
+  pass "valid python3 interpreter is selected"
+else
+  fail "valid python3 interpreter: rc=$RC argv=(${PY_ARGV[*]-})"
+fi
+
+# --- Scenario 2: a WindowsApps execution alias ------------------------------
+# The only `python3` on PATH is the Store stub; it must be rejected and the
+# resolver must fall through to a genuinely working `python` next in line.
+scenario2_root="$TMP_ROOT/scenario2"
+stub_dir="$scenario2_root/AppData/Local/Microsoft/WindowsApps"
+good_dir="$scenario2_root/real-python/bin"
+export MARKER_FILE="$scenario2_root/marker"
+write_stub "$stub_dir/python3" "$python3_stub_body"  # would pass if not filtered
+write_stub "$good_dir/python" "$python3_stub_body"
+run_resolver "$stub_dir:$good_dir"
+if [ "$RC" -eq 0 ] && [ "${#PY_ARGV[@]}" -eq 1 ] && [ "${PY_ARGV[0]}" = "$good_dir/python" ]; then
+  pass "WindowsApps execution alias is rejected, falls through to a real interpreter"
+else
+  fail "WindowsApps execution alias: rc=$RC argv=(${PY_ARGV[*]-})"
+fi
+
+# --- Scenario 3: a zero-byte executable --------------------------------------
+scenario3_root="$TMP_ROOT/scenario3"
+empty_dir="$scenario3_root/empty/bin"
+good_dir="$scenario3_root/real/bin"
+export MARKER_FILE="$scenario3_root/marker"
+mkdir -p "$empty_dir"
+: > "$empty_dir/python3"
+chmod +x "$empty_dir/python3"
+write_stub "$good_dir/python" "$python3_stub_body"
+run_resolver "$empty_dir:$good_dir"
+if [ "$RC" -eq 0 ] && [ "${#PY_ARGV[@]}" -eq 1 ] && [ "${PY_ARGV[0]}" = "$good_dir/python" ]; then
+  pass "zero-byte executable is rejected, falls through to a real interpreter"
+else
+  fail "zero-byte executable: rc=$RC argv=(${PY_ARGV[*]-})"
+fi
+
+# --- Scenario 4: an invalid or non-Python executable -------------------------
+scenario4_root="$TMP_ROOT/scenario4"
+bad_dir="$scenario4_root/bad/bin"
+good_dir="$scenario4_root/real/bin"
+export MARKER_FILE="$scenario4_root/marker"
+write_stub "$bad_dir/python3" "$non_python_stub_body"
+write_stub "$good_dir/python" "$python3_stub_body"
+run_resolver "$bad_dir:$good_dir"
+if [ "$RC" -eq 0 ] && [ "${#PY_ARGV[@]}" -eq 1 ] && [ "${PY_ARGV[0]}" = "$good_dir/python" ]; then
+  pass "non-Python executable is rejected, falls through to a real interpreter"
+else
+  fail "non-Python executable: rc=$RC argv=(${PY_ARGV[*]-})"
+fi
+
+# --- Scenario 5a: the py launcher, with Python 3 registered -----------------
+scenario5a_dir="$TMP_ROOT/scenario5a/bin"
+export MARKER_FILE="$TMP_ROOT/scenario5a/marker"
+write_stub "$scenario5a_dir/py" "$py_stub_supports_py3_body"
+run_resolver "$scenario5a_dir"
+if [ "$RC" -eq 0 ] && [ "${#PY_ARGV[@]}" -eq 2 ] && [ "${PY_ARGV[0]}" = "$scenario5a_dir/py" ] && [ "${PY_ARGV[1]}" = "-3" ]; then
+  pass "py launcher is selected and always paired with -3"
+else
+  fail "py launcher (-3 available): rc=$RC argv=(${PY_ARGV[*]-})"
+fi
+
+# --- Scenario 5b: the py launcher, with no Python 3 registered --------------
+# Must not be accepted just because it resolved on PATH — with nothing else
+# available, the resolver must report failure rather than fall back to a
+# Python 2 install.
+scenario5b_dir="$TMP_ROOT/scenario5b/bin"
+export MARKER_FILE="$TMP_ROOT/scenario5b/marker"
+write_stub "$scenario5b_dir/py" "$py_stub_no_py3_body"
+run_resolver "$scenario5b_dir"
+if [ "$RC" -eq 1 ] && [ "${#PY_ARGV[@]}" -eq 0 ]; then
+  pass "py launcher without Python 3 is rejected outright"
+else
+  fail "py launcher (-3 unavailable): rc=$RC argv=(${PY_ARGV[*]-})"
+fi
+
+# --- Wrapper: end-to-end with a resolved interpreter -------------------------
+# The wrapper must exec the resolved interpreter (plus -3, for py) against
+# validate_mp_credentials.py, forwarding stdin and any args.
+wrapper_dir="$TMP_ROOT/wrapper-good/bin"
+export MARKER_FILE="$TMP_ROOT/wrapper-good/marker"
+write_stub "$wrapper_dir/python3" "$python3_stub_body"
+PATH="$wrapper_dir:$REAL_BASH_DIR" "$REAL_BASH" "$WRAPPER" extra-arg < /dev/null
+wrapper_rc=$?
+recorded="$(cat "$MARKER_FILE" 2>/dev/null || true)"
+case "$recorded" in
+  invoked:*validate_mp_credentials.py\ extra-arg)
+    pass "wrapper execs the resolved python3 against the scanner, forwarding args"
+    ;;
+  *)
+    fail "wrapper end-to-end (python3): rc=$wrapper_rc recorded='$recorded'"
+    ;;
+esac
+
+# --- Wrapper: end-to-end via the py launcher ---------------------------------
+wrapper_py_dir="$TMP_ROOT/wrapper-py/bin"
+export MARKER_FILE="$TMP_ROOT/wrapper-py/marker"
+write_stub "$wrapper_py_dir/py" "$py_stub_supports_py3_body"
+PATH="$wrapper_py_dir:$REAL_BASH_DIR" "$REAL_BASH" "$WRAPPER" < /dev/null
+case "$(cat "$MARKER_FILE" 2>/dev/null || true)" in
+  invoked:-3\ *validate_mp_credentials.py)
+    pass "wrapper execs the py launcher with -3 against the scanner"
+    ;;
+  *)
+    fail "wrapper end-to-end (py launcher): recorded='$(cat "$MARKER_FILE" 2>/dev/null || true)'"
+    ;;
+esac
+
+# --- Wrapper: fails open when no working interpreter exists -----------------
+empty_path_dir="$TMP_ROOT/wrapper-none/empty-bin"
+mkdir -p "$empty_path_dir"
+PATH="$empty_path_dir:$REAL_BASH_DIR" "$REAL_BASH" "$WRAPPER" < /dev/null
+none_rc=$?
+if [ "$none_rc" -eq 0 ]; then
+  pass "wrapper fails open when no working interpreter is found"
+else
+  fail "wrapper fail-open: exited $none_rc, expected 0"
+fi
+
+if [ "$failures" -eq 0 ]; then
+  echo "All resolve-python.sh / run-credential-check.sh regression tests passed."
+  exit 0
+fi
+
+echo "$failures regression test(s) failed." >&2
+exit 1

--- a/scripts/validate_repository.sh
+++ b/scripts/validate_repository.sh
@@ -13,6 +13,7 @@ python3 -m json.tool plugins/mercadopago/.mcp.json >/dev/null
 python3 -m json.tool plugins/mercadopago/hooks/hooks.json >/dev/null
 python3 -m py_compile plugins/mercadopago/hooks/validate_mp_credentials.py
 python3 -m unittest plugins/mercadopago/hooks/test_validate_mp_credentials.py
+bash plugins/mercadopago/hooks/test-resolve-python.sh
 
 for script in plugins/mercadopago/scripts/*.mjs; do
   [ -f "$script" ] || continue


### PR DESCRIPTION
## Summary

Fixes #64 — both plugin hooks called a bare `python3` directly, which on Windows resolves to the Microsoft Store's execution-alias stub and leaks handles/commit charge in the `AppXSvc` service on every invocation, with no self-cleanup. `check-version.sh` runs on every `UserPromptSubmit`; the credential-scan hook runs on nearly every `PreToolUse` — combined, this leaked tens of GB of committed memory within a normal session on affected machines (measured: 134k+ handles, ~32 GB committed, in roughly half an hour of ordinary use), eventually starving the OS of committable memory and killing processes with no error surfaced.

Three small, independently-reviewable commits:

1. `check-version.sh` no longer needs an interpreter at all — it only reads one string field out of a small, trusted-format JSON file, so `grep`/`sed` replaces the `python3 -c` call entirely.
2. Adds `resolve-python.sh`, a small reusable helper that resolves a real Python interpreter, explicitly rejecting anything resolved from the Windows Store's `WindowsApps` execution-alias path (or any 0-byte stub binary).
3. Routes the `PreToolUse` credential-scan hook through a wrapper (`run-credential-check.sh`) that uses `resolve-python.sh` before invoking `validate_mp_credentials.py`, instead of trusting a bare `python3` on `PATH`. Falls open (same as the previous silent-no-op behavior) if no real interpreter is found, so this can only make the hook run in *more* cases than before, never fewer.

Plus a `CHANGELOG.md` entry under `[Unreleased]`.

## Validation

- [x] I ran `sh scripts/validate_repository.sh`. (One pre-existing, unrelated failure on this Windows machine in `test-point-tools.mjs` — `canonical-point-guide: server.js block not found` — reproduces identically on a clean `main` checkout with none of this PR's changes, so it isn't something this PR introduced or can fix. Every other check in the script passes, including the JSON/plugin-manifest validation, `validate_mp_credentials.py`'s own `py_compile` + `unittest` suite (9/9 passing, untouched by this PR), and `claude plugins validate --strict` for both the marketplace and the plugin.)
- [ ] I added or updated deterministic tests for behavior changes. (No existing test harness covers the bash hook scripts themselves — `test_validate_mp_credentials.py` tests the Python credential scanner's logic, which this PR doesn't touch. Verified manually instead — see below — and happy to add shell-based regression tests if you point me at a preferred pattern.)
- [x] I regenerated `docs/components.json` when component metadata changed. (N/A — no component metadata changed.)
- [x] I updated README/CHANGELOG for user-facing changes.
- [x] I did not add credentials, personal paths, internal registry URLs, or smoke artifacts.
- [x] Mutating MCP operations still require explicit user selection and on-demand authentication. (Unaffected — this PR only touches hook interpreter resolution.)
- [x] SDK installation/update still requires explicit authorization. (Unaffected.)

### Manual verification

```console
$ bash plugins/mercadopago/hooks/resolve-python.sh
/usr/bin/python3   # (or the real interpreter path on your machine)

$ echo '{"tool_name":"Bash","tool_input":{"command":"echo hello"}}' \
    | bash plugins/mercadopago/hooks/run-credential-check.sh; echo "exit: $?"
exit: 0

$ echo '{"tool_name":"Write","tool_input":{"file_path":"x.js","content":"const t = \"APP_USR-12345678-010101-abcdef0123456789abcdef01-123456789\";"}}' \
    | bash plugins/mercadopago/hooks/run-credential-check.sh; echo "exit: $?"
BLOCKED: Detected hardcoded Mercado Pago credential(s): MP Access Token. Use MP_ACCESS_TOKEN, MP_CLIENT_SECRET, or MP_WEBHOOK_SECRET from environment variables or a secret manager.
exit: 2
```

Same behavior as before the fix (allow benign input, block credential patterns) — the difference is that on Windows, this hook chain now actually executes instead of silently invoking a stub that does nothing.

## Security and privacy

No change to what the hooks scan, block, or report — only to how the interpreter running them is resolved. Worth noting as a secondary finding from the investigation: since the Microsoft Store `python3` stub doesn't execute real scripts, the credential-scan hook was likely a silent no-op on Windows machines without a real Python already resolving ahead of the Store alias on `PATH` — meaning the credential-leak protection may not have been active for some Windows users. This PR restores it.
