### PR TITLE
fix: avoid Bash plugin-root preflight

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "Mercado Pago Developer Experience"
   },
   "metadata": {
-    "version": "4.3.1",
+    "version": "4.3.2",
     "description": "Public marketplace of Claude Code plugins for Mercado Pago payment integration development"
   },
   "plugins": [
@@ -12,7 +12,7 @@
       "name": "mercadopago",
       "source": "./plugins/mercadopago",
       "description": "Mercado Pago integration toolkit for Claude Code. One agent routes to four skills: mp-integrate (wizard for Checkout Pro, Checkout API, Bricks, QR Code, Point, Subscriptions, Marketplace, Wallet Connect, Payouts, and SmartApps — plus migration of legacy Instore integrations to the Orders API), mp-webhooks (HMAC-validated receiver scaffold and diagnostics), mp-test-setup (test users, credentials, and test cards), and mp-review (quality and security checks). Scaffolding works offline where possible; live account and documentation operations use the official Mercado Pago MCP server on demand.",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "author": { "name": "Mercado Pago Developer Experience" },
       "repository": "https://github.com/mercadopago/mercadopago-claude-marketplace",
       "license": "Apache-2.0",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Plugin and Claude Code versions
-      placeholder: "Mercado Pago plugin 4.3.1; Claude Code 2.1.228"
+      placeholder: "Mercado Pago plugin 4.3.2; Claude Code 2.1.228"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [4.3.2] - 2026-08-26
+
+### Fixed
+
+- `/mp-integrate` reads routed skills directly from `${CLAUDE_PLUGIN_ROOT}` instead of probing the plugin root through a Bash preflight.
+
 ## [4.3.1] - 2026-08-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This repository builds the public Mercado Pago marketplace plugin for Claude
 Code. Runtime instructions, paths, hooks, examples, and validation must target
 Claude Code and must be safe for developers outside Mercado Pago/Mercado Libre.
 
-## Current architecture (v4.3.1)
+## Current architecture (v4.3.2)
 
 - One thin router: `plugins/mercadopago/agents/mp-integration-expert.md`.
 - Four passive skills only: `mp-integrate`, `mp-webhooks`, `mp-test-setup`, and

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Status: Beta](https://img.shields.io/badge/status-beta-orange)](https://github.com/mercadopago/mercadopago-claude-marketplace)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
-[![Version: 4.3.1](https://img.shields.io/badge/version-4.3.1-green)](./CHANGELOG.md)
+[![Version: 4.3.2](https://img.shields.io/badge/version-4.3.2-green)](./CHANGELOG.md)
 [![Platform: Claude Code](https://img.shields.io/badge/platform-Claude%20Code-7c3aed)](https://claude.com/claude-code)
 [![CI](https://github.com/mercadopago/mercadopago-claude-marketplace/actions/workflows/validate.yml/badge.svg)](https://github.com/mercadopago/mercadopago-claude-marketplace/actions/workflows/validate.yml)
 
@@ -35,6 +35,10 @@ A Claude Code plugin that provides guided integration support for the Mercado Pa
 - **Credential leak prevention** — hook inspects supported Claude tool inputs for hardcoded tokens and blocks secret-file reads in detected Mercado Pago projects
 - **OAuth-based auth** — triggered by MCP-backed operations or manually via `/mp-connect`; no keychain scripts needed
 - **4 slash commands** — `/mp-integrate`, `/mp-review`, `/mp-connect`, `/mp-test-cards`
+
+## What's new in v4.3.2
+
+- **Active plugin-root routing**: `/mp-integrate` now reads routed skills directly from `${CLAUDE_PLUGIN_ROOT}`, avoiding a Bash preflight before routing.
 
 ## What's new in v4.3.1
 

--- a/docs/components.json
+++ b/docs/components.json
@@ -1,7 +1,7 @@
 {
   "plugin": {
     "name": "mercadopago",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "description": "Mercado Pago integration toolkit for Claude Code. One agent routes to four skills: mp-integrate (wizard for Checkout Pro, Checkout API, Bricks, QR Code, Point, Subscriptions, Marketplace, Wallet Connect, Payouts, and SmartApps — plus migration of legacy Instore integrations to the Orders API), mp-webhooks (HMAC-validated receiver scaffold and diagnostics), mp-test-setup (test users, credentials, and test cards), and mp-review (quality and security checks). Scaffolding works offline where possible; live account and documentation operations use the official Mercado Pago MCP server on demand.",
     "repository": "https://github.com/mercadopago/mercadopago-claude-marketplace",
     "license": "Apache-2.0",
@@ -36,7 +36,7 @@
       "name": "mp-integration-expert",
       "type": "agent",
       "description": "Use when implementing, reviewing, or debugging any Mercado Pago payment integration. Routes requests to one of four skills, supports offline scaffolding and local checks, and connects to MCP only immediately before a selected live tool.",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "tags": [
         "payments",
         "mercadopago",
@@ -57,7 +57,7 @@
       "name": "mp-integrate",
       "type": "skill",
       "description": "Wizard that scaffolds a complete Mercado Pago integration from official and bundled sources, using MCP only for selected account actions or documentation gaps. Use whenever the developer wants to add or migrate a Mercado Pago payment flow.",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "tags": [
         "mercadopago",
         "integration",
@@ -85,7 +85,7 @@
       "name": "mp-review",
       "type": "skill",
       "description": "Review a Mercado Pago integration with a local cross-cutting security checklist and official MCP quality tools on demand. Use after the integration is in place, or when /mp-review is invoked.",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "tags": [
         "mercadopago",
         "review",
@@ -101,7 +101,7 @@
       "name": "mp-test-setup",
       "type": "skill",
       "description": "Create test users and add funds to them for Mercado Pago testing. Wraps create_test_user and add_money_test_user from the MCP. Clarifies that credentials come in APP_USR- (Orders API, Checkout Pro, Point, QR) and TEST- (Checkout API, Bricks, Payments API) formats — both are valid and actively issued.",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "tags": [
         "mercadopago",
         "testing",
@@ -117,7 +117,7 @@
       "name": "mp-webhooks",
       "type": "skill",
       "description": "Configure and validate Mercado Pago webhooks. Wraps the MCP webhook tools (save_webhook, notifications_history) and provides the HMAC-SHA256 signature validation pattern that every receiver must implement. Use when adding, debugging, or hardening notification handling.",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "tags": [
         "mercadopago",
         "webhooks",

--- a/plugins/mercadopago/.claude-plugin/plugin.json
+++ b/plugins/mercadopago/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "mercadopago",
   "displayName": "Mercado Pago",
   "description": "Mercado Pago integration toolkit for Claude Code. One agent routes to four skills: mp-integrate (wizard for Checkout Pro, Checkout API, Bricks, QR Code, Point, Subscriptions, Marketplace, Wallet Connect, Payouts, and SmartApps — plus migration of legacy Instore integrations to the Orders API), mp-webhooks (HMAC-validated receiver scaffold and diagnostics), mp-test-setup (test users, credentials, and test cards), and mp-review (quality and security checks). Scaffolding works offline where possible; live account and documentation operations use the official Mercado Pago MCP server on demand.",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "author": { "name": "Mercado Pago Developer Experience" },
   "repository": "https://github.com/mercadopago/mercadopago-claude-marketplace",
   "license": "Apache-2.0",

--- a/plugins/mercadopago/.mcp.json
+++ b/plugins/mercadopago/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.mercadopago.com/mcp",
       "headers": {
-        "X-Plugin-Version": "4.3.1",
+        "X-Plugin-Version": "4.3.2",
         "X-Invocation-Context": "router"
       }
     }

--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -12,6 +12,10 @@ After installing the plugin, start using it offline or connect to your Mercado P
 
 **Other IDEs (Cursor, VS Code, Windsurf, etc.):** add the HTTP server via your IDE's MCP settings panel with URL `https://mcp.mercadopago.com/mcp`, then complete the OAuth flow your IDE prompts. See `/mp-connect` for IDE-specific snippets.
 
+## Version 4.3.2
+
+- `/mp-integrate` reads routed skills directly from `${CLAUDE_PLUGIN_ROOT}`, avoiding a Bash preflight before routing.
+
 ## Version 4.3.1
 
 - Checkout Pro and Checkout API always resolve a concrete checkout CTA.

--- a/plugins/mercadopago/agents/mp-integration-expert.md
+++ b/plugins/mercadopago/agents/mp-integration-expert.md
@@ -7,7 +7,7 @@ tools: Read, Grep, Glob, Bash, WebFetch, AskUserQuestion, Write, Edit
 model: sonnet
 tags: [payments, mercadopago, checkout, webhooks, sdk, fintech, qr, subscriptions, marketplace]
 category: development
-version: 4.3.1
+version: 4.3.2
 ---
 
 # Mercado Pago Integration Expert

--- a/plugins/mercadopago/commands/mp-integrate.md
+++ b/plugins/mercadopago/commands/mp-integrate.md
@@ -23,16 +23,14 @@ Inspect `$ARGUMENTS`:
 
 ## Execution rules
 
-0. **Use the active Claude plugin root** — run this check via `Bash` as the first action:
-   ```bash
-   if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] || [ ! -f "${CLAUDE_PLUGIN_ROOT}/skills/mp-integrate/SKILL.md" ]; then
-     echo "PLUGIN_NOT_FOUND"
-     exit 1
-   fi
-   printf 'CLAUDE_PLUGIN_ROOT=%s\n' "$CLAUDE_PLUGIN_ROOT"
-   ```
-
-   Use `${CLAUDE_PLUGIN_ROOT}` for every bundled skill, reference, and script. Never scan a cache, load another marketplace copy, or copy the plugin's `.mcp.json` into the developer's project. If the check fails, instruct the developer to run `/reload-plugins` and retry.
+0. **Use the active Claude plugin root directly** — do not launch a `Bash`
+   preflight to inspect `CLAUDE_PLUGIN_ROOT`. Read the routed skill file with the
+   `Read` tool using its `${CLAUDE_PLUGIN_ROOT}/skills/...` path; Claude Code
+   resolves the exact placeholder to the active plugin version before the tool
+   call. Never scan a cache, load another marketplace copy, or copy the plugin's
+   `.mcp.json` into the developer's project. If `Read` reports that the routed
+   file does not exist, instruct the developer to run `/reload-plugins` and
+   retry.
 
 1. **Pre-flight + readiness — execute in this exact order. Do not call MCP just to inspect connection state.**
 

--- a/plugins/mercadopago/scripts/test-checkout-tools.mjs
+++ b/plugins/mercadopago/scripts/test-checkout-tools.mjs
@@ -129,6 +129,10 @@ try {
       || /cp\s+[\s\S]{0,200}\.mcp\.json/.test(integrateCommand)) {
     throw new Error('mp-integrate must use the active Claude plugin root and never copy MCP configuration');
   }
+  if (integrateCommand.includes('${CLAUDE_PLUGIN_ROOT:-}')
+      || integrateCommand.includes('PLUGIN_NOT_FOUND')) {
+    throw new Error('mp-integrate must not probe CLAUDE_PLUGIN_ROOT from a Bash tool call');
+  }
   const integrateSkill = fs.readFileSync(path.join(pluginRoot, 'skills/mp-integrate/SKILL.md'), 'utf8');
   if (!integrateSkill.includes('${CLAUDE_PLUGIN_ROOT}/scripts/validate-checkout-screen.mjs')
       || integrateSkill.includes('$MP_PLUGIN_ROOT/scripts/')) {

--- a/plugins/mercadopago/skills/mp-integrate/SKILL-migrate.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL-migrate.md
@@ -4,7 +4,7 @@ description: Migrates existing Mercado Pago Instore integrations (QR Code and Po
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.3.1"
+  version: "4.3.2"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, migration, orders-api, instore, qr, point"

--- a/plugins/mercadopago/skills/mp-integrate/SKILL.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL.md
@@ -4,7 +4,7 @@ description: Wizard that scaffolds a complete Mercado Pago integration from offi
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.3.1"
+  version: "4.3.2"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, integration, wizard, checkout, bricks, qr, point, subscriptions, marketplace, payouts, smartapps, orders, sdk"

--- a/plugins/mercadopago/skills/mp-integrate/references/products.md
+++ b/plugins/mercadopago/skills/mp-integrate/references/products.md
@@ -1,5 +1,5 @@
 # Mercado Pago — Product Reference
-# Version: 4.3.1 | Updated: 2026-08-21
+# Version: 4.3.2 | Updated: 2026-08-26
 # Source: Official Mercado Pago developer documentation
 #
 # This file is tier-2 in the documentation hierarchy:

--- a/plugins/mercadopago/skills/mp-review/SKILL.md
+++ b/plugins/mercadopago/skills/mp-review/SKILL.md
@@ -4,7 +4,7 @@ description: Review a Mercado Pago integration with a local cross-cutting securi
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.3.1"
+  version: "4.3.2"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, review, quality, checklist, security"
@@ -210,7 +210,7 @@ The report is the source of truth for the developer's next session: it tells the
 - MCP: `quality_checklist` (include only if called, with date/time)
 - MCP: `quality_evaluation` (include only if called, with the payment_id used)
 - MCP: `form_homologation` (include only if called)
-- Skill: `mp-review` v4.3.1
+- Skill: `mp-review` v4.3.2
 
 **Scores**: {X/Y required and Z/W best practices if verified; otherwise `official quality: N/A`}, {S}/9 security. **Verdict**: {Ready for production | Needs fixes | Blocked | Partial — MCP checks not verified}.
 ```

--- a/plugins/mercadopago/skills/mp-test-setup/SKILL.md
+++ b/plugins/mercadopago/skills/mp-test-setup/SKILL.md
@@ -4,7 +4,7 @@ description: Create test users and add funds to them for Mercado Pago testing. W
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.3.1"
+  version: "4.3.2"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, testing, test-user, sandbox, credentials"

--- a/plugins/mercadopago/skills/mp-webhooks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-webhooks/SKILL.md
@@ -4,7 +4,7 @@ description: Configure and validate Mercado Pago webhooks. Wraps the MCP webhook
 license: Apache-2.0
 copyright: "Copyright (c) 2026 Mercado Pago (MercadoLibre S.R.L.)"
 metadata:
-  version: "4.3.1"
+  version: "4.3.2"
   author: "Mercado Pago Developer Experience"
   category: "development"
   tags: "mercadopago, webhooks, notifications, ipn, hmac, signature"


### PR DESCRIPTION
## Summary

- Remove the Bash preflight that probes `CLAUDE_PLUGIN_ROOT` before routing `/mp-integrate`.
- Read the routed skill directly through the active plugin-root path, which Claude Code resolves to the installed plugin version.
- Extend the checkout-tool regression test to prevent the Bash probe from being reintroduced.
- Release the Mercado Pago plugin as `4.3.2`, updating shipped metadata, MCP request headers, documentation, changelog, and the generated catalog.

## Why

The command already has a stable active-plugin-root placeholder. Probing it through Bash adds an unnecessary execution step before routing, while direct reads keep runtime guidance aligned with the active plugin version.

## Validation

- `python3 -m json.tool` for repository and plugin manifests
- `python3 -m py_compile plugins/mercadopago/hooks/validate_mp_credentials.py`
- `node plugins/mercadopago/scripts/test-checkout-tools.mjs`
- `claude plugins validate .`
- `claude plugins validate plugins/mercadopago`
- `sh scripts/validate_repository.sh`