### PR TITLE
docs(for marketplace): seller stores and POS require a Point-type application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Marketplace guide: document that `GET /users/{user_id}/stores/search` and `GET /pos` return `403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES` for seller tokens issued by an online-payments application, and describe the second Point-type application pattern for marketplaces that need connected sellers' stores and POS.
+
 ## [4.3.2] - 2026-08-26
 
 ### Fixed

--- a/plugins/mercadopago/skills/mp-integrate/references/guides/marketplace.md
+++ b/plugins/mercadopago/skills/mp-integrate/references/guides/marketplace.md
@@ -1,5 +1,5 @@
 # Guide: Marketplace — Split Payments 1:1
-# Updated: 2026-08-21 | Sources: official Mercado Pago Split Payments and OAuth docs
+# Updated: 2026-08-28 | Sources: official Mercado Pago Split Payments and OAuth docs
 
 ## Choose the checkout contract first
 
@@ -49,6 +49,33 @@ the standalone Checkout API Orders contract onto Marketplace.
 7. Never create a fake seller record or silently fall back to the marketplace's
    own `MP_ACCESS_TOKEN`. Every split request must use the connected seller's
    decrypted OAuth access token in `Authorization: Bearer ...`.
+
+## Seller stores and POS require a Point-type application
+
+A seller OAuth token issued by an application registered for online payments
+(Checkout Pro, Checkout API, Bricks) can read the seller's payments through
+`/v1/payments/search`, but `GET /users/{user_id}/stores/search` and `GET /pos`
+return `403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES` for that token. Access to
+connected sellers' stores and POS is granted by the application type in the
+Developer Dashboard ("Pagos presenciales" / Point), not by an OAuth scope, so
+re-authorizing the seller with the same application does not fix it.
+
+When the marketplace needs stores or POS of connected sellers (for example, to
+map each Point terminal to a different branch or invoicing point):
+
+1. Do not reclassify an application that already has sellers connected for
+   online payments. Create a second application registered as Point, with its
+   own `MP_APP_ID`, `MP_CLIENT_SECRET`, and redirect URI.
+2. Persist which application issued each seller connection. Keep the online
+   application as the default and offer the Point application only to sellers
+   that need store/POS access; those sellers must complete a new OAuth
+   authorization with the Point application.
+3. Resolve the credentials for token exchange and refresh from the application
+   stored on the connection, never from a single global pair.
+
+A Point application token still returns the seller's payments through
+`/v1/payments/search`; verify this against a real seller account before
+migrating anyone.
 
 ## Trusted commerce contract
 


### PR DESCRIPTION
Seller OAuth tokens issued by an online-payments application can read `/v1/payments/search` but get **403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES** on `GET /users/{user_id}/stores/search` and `GET /pos`. Document that the access depends on the application type in the Developer Dashboard, and describe the second Point-type application pattern (`per-connection credentials, opt-in re-authorization`) for marketplaces that need connected sellers' stores and POS.

## Summary

Seller OAuth tokens issued by an application registered for online payments (Checkout Pro / Checkout API / Bricks) can read `/v1/payments/search`, but `GET /users/{user_id}/stores/search` and `GET /pos` return `403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES`. The access is granted by the application type in the Developer Dashboard ("Pagos presenciales" / Point), not by an OAuth scope, so re-authorizing the seller with the same application does not fix it. This is easy to hit when a marketplace wants to map each connected seller's Point terminal to a different branch or invoicing point, and the error message does not explain the cause.

This PR adds a short section to the Marketplace guide (`mp-integrate/references/guides/marketplace.md`) documenting the symptom and the pattern that resolves it without touching the existing online application: a second Point-type application with its own credentials, persisting which application issued each seller connection, and re-authorizing only the sellers that need store/POS access. It also adds a CHANGELOG entry under Unreleased.

It belongs in the existing `mp-integrate` skill as a stable guidance addition to an approved reference guide; no new skill, command, script, or manifest change.

## Validation

- [x] I ran `sh scripts/validate_repository.sh`.
- [ ] I added or updated deterministic tests for behavior changes.
- [ ] I regenerated `docs/components.json` when component metadata changed.
- [x] I updated README/CHANGELOG for user-facing changes.
- [x] I did not add credentials, personal paths, internal registry URLs, or smoke artifacts.
- [x] Mutating MCP operations still require explicit user selection and on-demand authentication.
- [x] SDK installation/update still requires explicit authorization.

## Security and privacy

No change. Documentation only. it reinforces per-connection credential resolution and does not introduce new permissions, hooks, MCP data, or generated code.
